### PR TITLE
Use the new ObjC nullability annotations

### DIFF
--- a/Code/CDAArray.h
+++ b/Code/CDAArray.h
@@ -6,6 +6,7 @@
 //
 //
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
 #import <ContentfulDeliveryAPI/CDAResource.h>
 
 /**
@@ -16,7 +17,7 @@
 /** @name Accessing Local Data */
 
 /** A list of items available locally. */
-@property (nonatomic, readonly) NSArray* items;
+@property (nonatomic, readonly) NSArray* __nonnull items;
 
 /** @name Information about Remote Data */
 
@@ -35,6 +36,6 @@
  *  For example, if there is a link to an Entry which no longer exists, there will be a `notResolvable`
  *  error in the `errors` array.
  */
-@property (nonatomic, readonly) NSArray* errors;
+@property (nonatomic, readonly) NSArray* __nonnull errors;
 
 @end

--- a/Code/CDAAsset.h
+++ b/Code/CDAAsset.h
@@ -6,6 +6,8 @@
 //
 //
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
+
 #import "CDAEntry.h"
 #import "CDAPersistedAsset.h"
 
@@ -60,7 +62,7 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
 /** @name Accessing the URL */
 
 /** The URL with which the asset was initialized. (read-only). */
-@property (nonatomic, readonly) NSURL* URL;
+@property (nonatomic, readonly) NSURL* __nullable URL;
 
 /**
  *  URL for retrieving an image asset which is being resized by the server.
@@ -71,7 +73,7 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *
  *  @return An URL for retrieving the resized image.
  */
--(NSURL *)imageURLWithSize:(CGSize)size;
+-(NSURL * __nullable)imageURLWithSize:(CGSize)size;
 
 /**
  *  URL for retrieving an image asset which is being processed by the server.
@@ -84,7 +86,7 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *
  *  @return An URL for retrieving the processed image.
  */
--(NSURL *)imageURLWithSize:(CGSize)size quality:(CGFloat)quality format:(CDAImageFormat)format;
+-(NSURL * __nullable)imageURLWithSize:(CGSize)size quality:(CGFloat)quality format:(CDAImageFormat)format;
 
 /**
  *  URL for retrieving an image asset which is being processed by the server.
@@ -110,13 +112,13 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *
  *  @return An URL for retrieving the processed image.
  */
--(NSURL *)imageURLWithSize:(CGSize)size
+-(NSURL * __nullable)imageURLWithSize:(CGSize)size
                    quality:(CGFloat)quality
                     format:(CDAImageFormat)format
                        fit:(CDAFitType)fit
-                     focus:(NSString*)focus
+                     focus:(NSString* __nullable)focus
                     radius:(CGFloat)radius
-                background:(NSString*)backgroundColor
+                background:(NSString* __nullable)backgroundColor
                progressive:(BOOL)progressive;
 
 /** @name Accessing Localized Content */
@@ -133,16 +135,16 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *  be accurate for Assets obtained from a `CDASyncedSpace`originally.
  *
  */
-@property (nonatomic) NSString* locale;
+@property (nonatomic) NSString* __nonnull locale;
 
 /** @name Accessing Meta-Data */
 
 /** All fields associated with this asset. */
-@property (nonatomic, readonly) NSDictionary* fields;
+@property (nonatomic, readonly) NSDictionary* __nonnull fields;
 /** Returns `YES` if this asset is referencing an image file, `NO` otherwise. */
 @property (nonatomic, readonly) BOOL isImage;
 /** File type of the asset. */
-@property (nonatomic, readonly) NSString* MIMEType;
+@property (nonatomic, readonly) NSString* __nullable MIMEType;
 /** Size of the asset, if it is an image. */
 @property (nonatomic, readonly) CGSize size;
 
@@ -155,7 +157,7 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *
  *  @return Cached data or `nil` if none was found.
  */
-+(NSData*)cachedDataForAsset:(CDAAsset*)asset;
++(NSData* __nullable)cachedDataForAsset:(CDAAsset* __nonnull)asset;
 
 /**
  *  Access previously cached data for an Asset.
@@ -165,7 +167,7 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *
  *  @return Cached data or `nil` if none was found.
  */
-+(NSData*)cachedDataForPersistedAsset:(id<CDAPersistedAsset>)persistedAsset client:(CDAClient*)client;
++(NSData* __nullable)cachedDataForPersistedAsset:(id<CDAPersistedAsset> __nonnull)persistedAsset client:(CDAClient* __nonnull)client;
 
 /**
  *  Cache the data of an Asset to disk.
@@ -175,9 +177,9 @@ typedef NS_ENUM(NSInteger, CDAFitType) {
  *  @param forceOverwrite If `NO` and file already exists, nothing will be done.
  *  @param handler        This block will be called after persisting the asset.
  */
-+(void)cachePersistedAsset:(id<CDAPersistedAsset>)persistedAsset
-                    client:(CDAClient*)client
++(void)cachePersistedAsset:(id<CDAPersistedAsset> __nonnull)persistedAsset
+                    client:(CDAClient* __nonnull)client
           forcingOverwrite:(BOOL)forceOverwrite
-         completionHandler:(void (^)(BOOL success))handler;
+         completionHandler:(void (^ __nonnull)(BOOL success))handler;
 
 @end

--- a/Code/CDAClient.h
+++ b/Code/CDAClient.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
+
 @class CDAArray;
 @class CDAAsset;
 @class CDAConfiguration;
@@ -28,13 +30,15 @@ typedef NS_ENUM(NSInteger, CDAResourceType) {
     CDAResourceTypeEntry,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef void(^CDAArrayFetchedBlock)(CDAResponse* response, CDAArray* array);
 typedef void(^CDAAssetFetchedBlock)(CDAResponse* response, CDAAsset* asset);
-typedef void(^CDAContentTypeFetchedBlock)(CDAResponse* response, CDAContentType* contentType);
+typedef void(^CDAContentTypeFetchedBlock)(CDAResponse* __nullable response, CDAContentType* contentType);
 typedef void(^CDAEntryFetchedBlock)(CDAResponse* response, CDAEntry* entry);
 typedef void(^CDAObjectFetchedBlock)(CDAResponse* response, id responseObject);
-typedef void(^CDARequestFailureBlock)(CDAResponse* response, NSError* error);
-typedef void(^CDASpaceFetchedBlock)(CDAResponse* response, CDASpace* space);
+typedef void(^CDARequestFailureBlock)(CDAResponse* __nullable response, NSError* error);
+typedef void(^CDASpaceFetchedBlock)(CDAResponse* __nullable response, CDASpace* space);
 typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace* space);
 
 /**
@@ -80,9 +84,9 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @param failure A block which gets called if an error occured during the retrieval process.
  *  @return The request used for fetching data.
  */
--(CDARequest*)fetchAssetsMatching:(NSDictionary*)query
+-(CDARequest*)fetchAssetsMatching:(NSDictionary* __nullable)query
                           success:(CDAArrayFetchedBlock)success
-                          failure:(CDARequestFailureBlock)failure;
+                          failure:(CDARequestFailureBlock __nullable)failure;
 
 /**
  *  Fetch all Assets from the server.
@@ -92,7 +96,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @return The request used for fetching data.
  */
 -(CDARequest*)fetchAssetsWithSuccess:(CDAArrayFetchedBlock)success
-                             failure:(CDARequestFailureBlock)failure;
+                             failure:(CDARequestFailureBlock __nullable)failure;
 
 /**
  *  Fetch one specific Asset from the server.
@@ -104,7 +108,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  */
 -(CDARequest*)fetchAssetWithIdentifier:(NSString*)identifier
                                success:(CDAAssetFetchedBlock)success
-                               failure:(CDARequestFailureBlock)failure;
+                               failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Fetching Content Types */
 
@@ -116,7 +120,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @return The request used for fetching data.
  */
 -(CDARequest*)fetchContentTypesWithSuccess:(CDAArrayFetchedBlock)success
-                                   failure:(CDARequestFailureBlock)failure;
+                                   failure:(CDARequestFailureBlock __nullable)failure;
 
 /**
  *  Fetch one specific Content Type from the server.
@@ -128,7 +132,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  */
 -(CDARequest*)fetchContentTypeWithIdentifier:(NSString*)identifier
                                      success:(CDAContentTypeFetchedBlock)success
-                                     failure:(CDARequestFailureBlock)failure;
+                                     failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Fetching Entries */
 
@@ -141,9 +145,9 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @param failure A block which gets called if an error occured during the retrieval process.
  *  @return The request used for fetching data.
  */
--(CDARequest*)fetchEntriesMatching:(NSDictionary*)query
+-(CDARequest*)fetchEntriesMatching:(NSDictionary* __nullable)query
                            success:(CDAArrayFetchedBlock)success
-                           failure:(CDARequestFailureBlock)failure;
+                           failure:(CDARequestFailureBlock __nullable)failure;
 
 /**
  *  Fetch all Entries from the server.
@@ -153,7 +157,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @return The request used for fetching data.
  */
 -(CDARequest*)fetchEntriesWithSuccess:(CDAArrayFetchedBlock)success
-                              failure:(CDARequestFailureBlock)failure;
+                              failure:(CDARequestFailureBlock __nullable)failure;
 
 /**
  *  Fetch one specific Entry from the server.
@@ -165,7 +169,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  */
 -(CDARequest*)fetchEntryWithIdentifier:(NSString*)identifier
                                success:(CDAEntryFetchedBlock)success
-                               failure:(CDARequestFailureBlock)failure;
+                               failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Fetching Resources */
 
@@ -184,9 +188,9 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @return The request used for fetching data.
  */
 -(CDARequest*)fetchResourcesOfType:(CDAResourceType)resourceType
-                          matching:(NSDictionary*)query
+                          matching:(NSDictionary* __nullable)query
                            success:(CDAArrayFetchedBlock)success
-                           failure:(CDARequestFailureBlock)failure;
+                           failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Fetching Spaces */
 
@@ -198,7 +202,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @return The request used for fetching data.
  */
 -(CDARequest*)fetchSpaceWithSuccess:(CDASpaceFetchedBlock)success
-                            failure:(CDARequestFailureBlock)failure;
+                            failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Fetching Arrays */
 
@@ -214,7 +218,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  */
 -(void)fetchAllItemsFromArray:(CDAArray*)array
                       success:(void (^)(NSArray* items))success
-                      failure:(CDARequestFailureBlock)failure;
+                      failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Synchronization */
 
@@ -234,7 +238,7 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *  @return The request used for fetching data.
  */
 -(CDARequest*)initialSynchronizationWithSuccess:(CDASyncedSpaceFetchedBlock)success
-                                        failure:(CDARequestFailureBlock)failure;
+                                        failure:(CDARequestFailureBlock __nullable)failure;
 
 /**
  *  Perform the initial synchronization of a Space.
@@ -253,9 +257,9 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  *
  *  @return The request used for fetching data.
  */
--(CDARequest*)initialSynchronizationMatching:(NSDictionary*)query
+-(CDARequest*)initialSynchronizationMatching:(NSDictionary* __nullable)query
                                      success:(CDASyncedSpaceFetchedBlock)success
-                                     failure:(CDARequestFailureBlock)failure;
+                                     failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Register classes for custom value objects */
 
@@ -301,6 +305,8 @@ typedef void(^CDASyncedSpaceFetchedBlock)(CDAResponse* response, CDASyncedSpace*
  */
 -(void)resolveLinksFromArray:(NSArray*)array
                      success:(void (^)(NSArray* items))success
-                     failure:(CDARequestFailureBlock)failure;
+                     failure:(CDARequestFailureBlock __nullable)failure;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDAConfiguration.h
+++ b/Code/CDAConfiguration.h
@@ -8,6 +8,10 @@
 
 @import Foundation;
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Class representing additional configuration options for a `CDAClient`.
  */
@@ -59,3 +63,5 @@
 @property (nonatomic) BOOL previewMode;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDAContentType.h
+++ b/Code/CDAContentType.h
@@ -6,9 +6,12 @@
 //
 //
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
 #import <ContentfulDeliveryAPI/CDAResource.h>
 
 @class CDAField;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  Content Types are schemas describing the shape of Entries. They mainly consist of a list of fields 
@@ -29,15 +32,17 @@
  @param identifier The `sys.id` to look for in the list of fields.
  @return The specific field requested, or `nil` if none matches.
  */
--(CDAField*)fieldForIdentifier:(NSString*)identifier;
+-(CDAField* __nullable)fieldForIdentifier:(NSString*)identifier;
 
 /** @name Accessing Meta-Data */
 
 /** The identifier of the Field which should be displayed as a title for Entries */
-@property (nonatomic, readonly) NSString* displayField;
+@property (nonatomic, readonly) NSString* __nullable displayField;
 /** Name of the Content Type. */
 @property (nonatomic, readonly) NSString* name;
 /** Description of the Content Type. */
 @property (nonatomic, readonly) NSString* userDescription;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDAEntry.h
+++ b/Code/CDAEntry.h
@@ -8,9 +8,12 @@
 
 @import MapKit;
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
 #import <ContentfulDeliveryAPI/CDAResource.h>
 
 @class CDAContentType;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** 
  Entries represent textual content in a Space. An Entry's data adheres to a certain Content Type.
@@ -79,3 +82,5 @@
 -(id)mapFieldsToObject:(NSObject*)object usingMapping:(NSDictionary*)dictionary;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDAError.h
+++ b/Code/CDAError.h
@@ -6,7 +6,10 @@
 //
 //
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
 #import <ContentfulDeliveryAPI/CDAResource.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 extern NSString* const CDAErrorDomain;
 
@@ -26,3 +29,5 @@ extern NSString* const CDAErrorDomain;
 @property (nonatomic, readonly) NSString* message;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDAField.h
+++ b/Code/CDAField.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
+
 /**
  Possible field types.
  
@@ -42,6 +44,8 @@ typedef NS_ENUM(NSInteger, CDAFieldType) {
     CDAFieldTypeAsset,
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** A `CDAField` describes a single property of a `CDAEntry`. */
 @interface CDAField : NSObject <NSCoding, NSSecureCoding>
 
@@ -62,3 +66,5 @@ typedef NS_ENUM(NSInteger, CDAFieldType) {
 @property (nonatomic, readonly) CDAFieldType itemType;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDANullabilityStubs.h
+++ b/Code/CDANullabilityStubs.h
@@ -1,0 +1,20 @@
+//
+//  CDANullabilityStubs.h
+//  ContentfulSDK
+//
+//  Created by Boris Bügling on 15/04/15.
+//
+//
+
+// Thanks to https://gist.github.com/steipete/d9f519858fe5fb5533eb
+#if !__has_feature(nullability)
+#define NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_END
+#define nullable
+#define nonnull
+#define null_unspecified
+#define null_resettable
+#define __nullable
+#define __nonnull
+#define __null_unspecified
+#endif

--- a/Code/CDAPersistenceManager.h
+++ b/Code/CDAPersistenceManager.h
@@ -11,6 +11,8 @@
 #import <ContentfulDeliveryAPI/CDAPersistedEntry.h>
 #import <ContentfulDeliveryAPI/CDAPersistedSpace.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  Subclasses of this class manage a persistent store.
  *
@@ -30,7 +32,7 @@
 *
 *  @return An initialized `CDAPersistenceManager` or `nil` if the object couldn't be created.
 */
--(id)initWithClient:(CDAClient*)client;
+-(id __nullable)initWithClient:(CDAClient*)client;
 
 /**
  *  Initializes a new `CDAPersistenceManager` object. Using this initializer will use queries for
@@ -41,7 +43,7 @@
  *
  *  @return An initialized `CDAPersistenceManager` or `nil` if the object couldn't be created.
  */
--(id)initWithClient:(CDAClient *)client query:(NSDictionary*)query;
+-(id __nullable)initWithClient:(CDAClient *)client query:(NSDictionary*)query;
 
 /** @name Performing Synchronizations */
 
@@ -171,7 +173,7 @@
  *
  *  @return The Asset with the given identifier or `nil` if it could not be found.
  */
--(id<CDAPersistedAsset>)fetchAssetWithIdentifier:(NSString*)identifier;
+-(id<CDAPersistedAsset> __nullable)fetchAssetWithIdentifier:(NSString*)identifier;
 
 /**
  *  Fetch all Entries from the store.
@@ -189,7 +191,7 @@
  *
  *  @return The Entry with the given identifier or `nil` if it could not be found.
  */
--(id<CDAPersistedEntry>)fetchEntryWithIdentifier:(NSString*)identifier;
+-(id<CDAPersistedEntry> __nullable)fetchEntryWithIdentifier:(NSString*)identifier;
 
 /**
  *  Fetch a Space from the persistent store.
@@ -198,7 +200,7 @@
  *
  *  @return The fetched Space or `nil` if none could be retrieved.
  */
--(id<CDAPersistedSpace>)fetchSpaceFromDataStore;
+-(id<CDAPersistedSpace> __nullable)fetchSpaceFromDataStore;
 
 /**
  *  Whether any data has changed since the last synchronization.
@@ -241,3 +243,5 @@
 +(void)seedFromBundleWithInitialCacheDirectory:(NSString*)initialCacheDirectory;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CDARequest.h
+++ b/Code/CDARequest.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
+
 /**
  A request encapsulates all necessary information for retrieving specific resources.
  */
@@ -16,20 +18,20 @@
 /** @name Accessing URL Connection Information */
 
 /** Error which occured during the lifetime of the request, if any. */
-@property (readonly, nonatomic) NSError *error;
+@property (readonly, nonatomic) NSError* __nullable error;
 /** The actual request being sent to the server. */
-@property (readonly, nonatomic) NSURLRequest *request;
+@property (readonly, nonatomic) NSURLRequest* __nullable request;
 /** The underlying response received from the server. */
-@property (readonly, nonatomic) NSHTTPURLResponse *response;
+@property (readonly, nonatomic) NSHTTPURLResponse* __nullable response;
 
 /** @name Accessing Response Data */
 
 /** The raw data received from the server. */
-@property (readonly, nonatomic) NSData *responseData;
+@property (readonly, nonatomic) NSData* __nullable responseData;
 /** The processed response data, usually an instance of a `CDAResource` subclass. */
-@property (readonly, nonatomic) id responseObject;
+@property (readonly, nonatomic) id __nullable responseObject;
 /** String representation of the data received from the server. */
-@property (readonly, nonatomic) NSString *responseString;
+@property (readonly, nonatomic) NSString* __nullable responseString;
 /** Encoding used for the response. */
 @property (readonly, nonatomic) NSStringEncoding responseStringEncoding;
 

--- a/Code/CDASpace.h
+++ b/Code/CDASpace.h
@@ -6,6 +6,7 @@
 //
 //
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
 #import <ContentfulDeliveryAPI/CDAResource.h>
 
 /**
@@ -16,10 +17,10 @@
 /** @name Accessing Meta-Data */
 
 /** Default locale for this Space. */
-@property (nonatomic, readonly) NSString* defaultLocale;
+@property (nonatomic, readonly) NSString* __nonnull defaultLocale;
 /** Possible locales used for Entries in this Space. */
-@property (nonatomic, readonly) NSArray* locales;
+@property (nonatomic, readonly) NSArray* __nullable locales;
 /** The name of this Space. */
-@property (nonatomic, readonly) NSString* name;
+@property (nonatomic, readonly) NSString* __nonnull name;
 
 @end

--- a/Code/CDASyncedSpace.h
+++ b/Code/CDASyncedSpace.h
@@ -12,6 +12,8 @@
 @class CDAEntry;
 @class CDASyncedSpace;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  The delegate of a `CDASyncedSpace` object must adopt the `CDASyncedSpaceDelegate`
  protocol. The optional methods will inform the delegate about updates on the contents of the target
@@ -88,14 +90,14 @@
 /** @name Accessing Space Contents */
 
 /** All published Assets in the given Space. */
-@property (nonatomic, readonly) NSArray* assets;
+@property (nonatomic, readonly) NSArray* __nullable assets;
 /** All published Entries in the given Space. */
-@property (nonatomic, readonly) NSArray* entries;
+@property (nonatomic, readonly) NSArray* __nullable entries;
 
 /** @name Managing the Delegate */
 
 /** The object acts as a delegate on the receiving synchronized Space. */
-@property (nonatomic) id<CDASyncedSpaceDelegate> delegate;
+@property (nonatomic) id<CDASyncedSpaceDelegate> __nullable delegate;
 
 /** @name Perform Synchronizations */
 
@@ -109,7 +111,7 @@
  *  @param success A block which is called upon the successful synchronization of the Space.
  *  @param failure A block which is called if any errors occur during the synchronization process.
  */
--(void)performSynchronizationWithSuccess:(void (^)())success failure:(CDARequestFailureBlock)failure;
+-(void)performSynchronizationWithSuccess:(void (^)())success failure:(CDARequestFailureBlock __nullable)failure;
 
 /** @name Persisting Synchronized Spaces */
 
@@ -162,7 +164,7 @@
  *  only create and delete operations will be reported to the delegate of a shallow synchronized Space.
  *
  */
-@property (nonatomic) NSDate* lastSyncTimestamp;
+@property (nonatomic) NSDate* __nullable lastSyncTimestamp;
 
 /**
  Retrieve the synchronization token for the next synchronization operation.
@@ -175,3 +177,5 @@
 @property (nonatomic, readonly) NSString* syncToken;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/CoreData/CoreDataManager.m
+++ b/Code/CoreData/CoreDataManager.m
@@ -12,6 +12,7 @@
 #import <ContentfulDeliveryAPI/CDAContentType.h>
 #import <ContentfulDeliveryAPI/CDAEntry.h>
 
+#import "CDAUtilities.h"
 #import "CoreDataManager.h"
 
 @interface CoreDataManager ()

--- a/Code/UIKit/CDAEntriesViewController.h
+++ b/Code/UIKit/CDAEntriesViewController.h
@@ -28,8 +28,8 @@
  *  @param entriesViewController    The sender of the delegate method.
  *  @param entry                    The Entry associated with the row the user selected.
  */
--(void)entriesViewController:(CDAEntriesViewController*)entriesViewController
-       didSelectRowWithEntry:(CDAEntry*)entry;
+-(void)entriesViewController:(CDAEntriesViewController* __nonnull)entriesViewController
+       didSelectRowWithEntry:(CDAEntry* __nonnull)entry;
 
 @end
 
@@ -49,6 +49,6 @@
  
  The delegate must adopt the `CDAEntriesViewControllerDelegate` protocol. The delegate is not retained.
  */
-@property (nonatomic, weak) id<CDAEntriesViewControllerDelegate> delegate;
+@property (nonatomic, weak) id<CDAEntriesViewControllerDelegate> __nullable delegate;
 
 @end

--- a/Code/UIKit/CDAEntriesViewController.m
+++ b/Code/UIKit/CDAEntriesViewController.m
@@ -35,7 +35,10 @@
     }
     
     if ([self.delegate respondsToSelector:@selector(entriesViewController:didSelectRowWithEntry:)]) {
-        [self.delegate entriesViewController:self didSelectRowWithEntry:self.items[indexPath.row]];
+        id entry = self.items[indexPath.row];
+        if (entry) {
+            [self.delegate entriesViewController:self didSelectRowWithEntry:entry];
+        }
     }
 }
 

--- a/Code/UIKit/CDAFieldsViewController.h
+++ b/Code/UIKit/CDAFieldsViewController.h
@@ -10,6 +10,8 @@
 
 @class CDAEntry;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  `CDAFieldsViewController` is designed to make it easy to display Field values of a single Entry in a
  simple way.
@@ -29,7 +31,7 @@
  *  @return An array of Field identifiers as strings. Any identifiers which do not match actual
  *      Fields on the Entry will be ignored.
  */
-@property (nonatomic, readonly) NSArray* visibleFields;
+@property (nonatomic, readonly) NSArray* __nullable visibleFields;
 
 /** @name Initializing the CDAEntriesViewController Object */
 
@@ -40,7 +42,7 @@
  *
  *  @return An initialized `CDAFieldsViewController` or `nil` if the object couldn't be created.
  */
--(id)initWithEntry:(CDAEntry*)entry;
+-(id __nullable)initWithEntry:(CDAEntry*)entry;
 
 /**
  *  Initializes a new instance with the given Entry.
@@ -82,3 +84,5 @@
 -(void)showError:(NSError*)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/UIKit/CDAFieldsViewController.m
+++ b/Code/UIKit/CDAFieldsViewController.m
@@ -120,16 +120,23 @@
     if (self) {
         self.entry = entry;
 
-        switch ([entry.contentType fieldForIdentifier:entry.contentType.displayField].type) {
+        NSString* displayField = entry.contentType.displayField;
+        CDAFieldType titleType = CDAFieldTypeNone;
+
+        if (displayField) {
+            titleType = [entry.contentType fieldForIdentifier:displayField].type;
+        }
+
+        switch (titleType) {
             case CDAFieldTypeText:
             case CDAFieldTypeSymbol:
-                self.title = entry.fields[entry.contentType.displayField];
+                self.title = entry.fields[displayField];
                 break;
 
             case CDAFieldTypeInteger:
             case CDAFieldTypeBoolean:
             case CDAFieldTypeNumber:
-                self.title = [entry.fields[entry.contentType.displayField] stringValue];
+                self.title = [entry.fields[displayField] stringValue];
                 break;
 
             case CDAFieldTypeArray:

--- a/Code/UIKit/CDAMapViewController.h
+++ b/Code/UIKit/CDAMapViewController.h
@@ -18,18 +18,18 @@
 @interface CDAMapViewController : UIViewController
 
 /** The underlying map view managed by this view controller. */
-@property (nonatomic, readonly) MKMapView* mapView;
+@property (nonatomic, readonly) MKMapView* __nonnull mapView;
 
 /** @name Configure Data to Display */
 
 /** Identifier for the Field which contains the coordinate for each `MKAnnotation`. */
-@property (nonatomic, copy) NSString* coordinateFieldIdentifier;
+@property (nonatomic, copy) NSString* __nullable coordinateFieldIdentifier;
 
 /** Identifier for the Field which contains the subtitle for each `MKAnnotation`. */
-@property (nonatomic, copy) NSString* subtitleFieldIdentifier;
+@property (nonatomic, copy) NSString* __nullable subtitleFieldIdentifier;
 
 /** Identifier for the Field which contains the title for each `MKAnnotation`. */
-@property (nonatomic, copy) NSString* titleFieldIdentifier;
+@property (nonatomic, copy) NSString* __nullable titleFieldIdentifier;
 
 /** @name Configure Data to Fetch */
 
@@ -40,16 +40,16 @@
  
  The client is not retained.
  */
-@property (nonatomic, weak) CDAClient* client;
+@property (nonatomic, weak) CDAClient* __nullable client;
 
 /** The items which are currently displayed in this view controller's table view. */
-@property (nonatomic, readonly) NSArray* items;
+@property (nonatomic, readonly) NSArray* __nullable items;
 
 /**
  The query parameters used for fetching Entries. By default, all Entries from the Space associated
  with the client will be fetched.
  */
-@property (nonatomic) NSDictionary* query;
+@property (nonatomic) NSDictionary* __nullable query;
 
 /**
  Activate the built-in support for caching Resources offline.

--- a/Code/UIKit/CDAMapViewController.m
+++ b/Code/UIKit/CDAMapViewController.m
@@ -83,7 +83,8 @@
         annotation.identifier = entry.identifier;
         
         if (self.coordinateFieldIdentifier) {
-            annotation.coordinate = [entry CLLocationCoordinate2DFromFieldWithIdentifier:self.coordinateFieldIdentifier];
+            NSString* identifier = self.coordinateFieldIdentifier;
+            annotation.coordinate = [entry CLLocationCoordinate2DFromFieldWithIdentifier:identifier];
         }
         
         if (self.subtitleFieldIdentifier) {

--- a/Code/UIKit/CDAResourceCell.h
+++ b/Code/UIKit/CDAResourceCell.h
@@ -8,6 +8,10 @@
 
 @import UIKit;
 
+#import <ContentfulDeliveryAPI/CDANullabilityStubs.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 /** UICollectionViewCell subclass for displaying Resources. */
 @interface CDAResourceCell : UICollectionViewCell
 
@@ -22,3 +26,5 @@
 @property (nonatomic) NSURL* imageURL;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/UIKit/CDAResourcesCollectionViewController.h
+++ b/Code/UIKit/CDAResourcesCollectionViewController.h
@@ -35,13 +35,13 @@
 *  @return An initialized `CDAResourcesCollectionViewController` or `nil` if the object
 *  couldn't be created.
 */
--(id)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
-                      cellMapping:(NSDictionary*)cellMapping;
+-(id __nullable)initWithCollectionViewLayout:(UICollectionViewLayout * __nonnull)layout
+                      cellMapping:(NSDictionary* __nonnull)cellMapping;
 
 /** @name Access Displayed Data */
 
 /** The items which are currently displayed in this view controller's table view. */
-@property (nonatomic, readonly) NSArray* items;
+@property (nonatomic, readonly) NSArray* __nullable items;
 
 /** @name Configure Data to Fetch */
 
@@ -52,16 +52,16 @@
  
  The client is not retained.
  */
-@property (nonatomic, weak) CDAClient* client;
+@property (nonatomic, weak) CDAClient* __nullable client;
 
 /** Locale to use when querying Resources. */
-@property (nonatomic, copy) NSString* locale;
+@property (nonatomic, copy) NSString* __nullable locale;
 
 /**
  The query parameters used for fetching Resources. By default, all Resources from the Space associated
  with the client will be fetched.
  */
-@property (nonatomic) NSDictionary* query;
+@property (nonatomic) NSDictionary* __nullable query;
 
 /** The type of Resources which ought to be fetched. */
 @property (nonatomic) CDAResourceType resourceType;
@@ -90,7 +90,7 @@
  own `UICollectionViewCell` subclass, override this method in your subclass of 
  `CDAResourcesCollectionViewController`.
  */
-+(Class)cellClass;
++(Class __nonnull)cellClass;
 
 /**
  *  By default, errors related to requests made to the Contentful API will be displayed in a
@@ -99,6 +99,6 @@
  *
  *  @param error The error which occured.
  */
--(void)showError:(NSError*)error;
+-(void)showError:(NSError* __nonnull)error;
 
 @end

--- a/Code/UIKit/CDAResourcesViewController.h
+++ b/Code/UIKit/CDAResourcesViewController.h
@@ -12,6 +12,8 @@
 
 @class CDAResource;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  `CDAResourcesViewController` is designed to make it easy to display a list of Resources in a table view.
  
@@ -73,23 +75,23 @@
  
  The client is not retained.
  */
-@property (nonatomic, weak) CDAClient* client;
+@property (nonatomic, weak) CDAClient* __nullable client;
 
 /** 
  Locale to use when querying Resources. 
  
  This property has no effect when showing locally available Resources.
  */
-@property (nonatomic, copy) NSString* locale;
+@property (nonatomic, copy) NSString* __nullable locale;
 
 /** The items which are currently displayed in this view controller's table view. */
-@property (nonatomic, readonly) NSArray* items;
+@property (nonatomic, readonly) NSArray* __nullable items;
 
 /**
  The query parameters used for fetching Resources. By default, all Resources from the Space associated
  with the client will be fetched.
  */
-@property (nonatomic) NSDictionary* query;
+@property (nonatomic) NSDictionary* __nullable query;
 
 /** The type of Resources which ought to be fetched. */
 @property (nonatomic) CDAResourceType resourceType;
@@ -129,3 +131,5 @@
 -(void)showError:(NSError*)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Code/UIKit/CDAResourcesViewController.m
+++ b/Code/UIKit/CDAResourcesViewController.m
@@ -261,8 +261,12 @@
     if (indexPath.section != 0) {
         return;
     }
-    
-    [self didSelectRowWithResource:self.items[indexPath.row]];
+
+    id entry = self.items[indexPath.row];
+
+    if (entry) {
+        [self didSelectRowWithResource:entry];
+    }
 }
 
 @end

--- a/Code/UIKit/UIImageView+CDAAsset.h
+++ b/Code/UIKit/UIImageView+CDAAsset.h
@@ -28,7 +28,7 @@
  *  @param asset An Asset pointing to an image.
  *  @exception NSIllegalArgumentException If the Asset is pointing to an image.
  */
--(void)cda_setImageWithAsset:(CDAAsset*)asset;
+-(void)cda_setImageWithAsset:(CDAAsset* __nonnull)asset;
 
 /**
  *  Set this image view's image to the image file retrieved from the given Asset.
@@ -39,7 +39,7 @@
  *  @param size             The desired size of the image. It will be resized by the server.
  *  @exception NSIllegalArgumentException If the Asset is pointing to an image.
  */
--(void)cda_setImageWithAsset:(CDAAsset*)asset size:(CGSize)size;
+-(void)cda_setImageWithAsset:(CDAAsset* __nonnull)asset size:(CGSize)size;
 
 /**
  *  Set this image view's image to the image file retrieved from the given Asset. 
@@ -51,7 +51,8 @@
  *  @param placeholderImage An alternative image which will be displayed until `asset` is loaded.
  *  @exception NSIllegalArgumentException If the Asset is pointing to an image.
  */
--(void)cda_setImageWithAsset:(CDAAsset *)asset placeholderImage:(UIImage *)placeholderImage;
+-(void)cda_setImageWithAsset:(CDAAsset* __nonnull)asset
+            placeholderImage:(UIImage* __nullable)placeholderImage;
 
 /**
  *  Set this image view's image to the image file retrieved from the given Asset.
@@ -64,9 +65,9 @@
  *  @param placeholderImage An alternative image which will be displayed until `asset` is loaded.
  *  @exception NSIllegalArgumentException If the Asset is pointing to an image.
  */
--(void)cda_setImageWithAsset:(CDAAsset *)asset
+-(void)cda_setImageWithAsset:(CDAAsset* __nonnull)asset
                         size:(CGSize)size
-            placeholderImage:(UIImage *)placeholderImage;
+            placeholderImage:(UIImage* __nullable)placeholderImage;
 
 /**
  *  Set this image view's image to the image file retrieved from the given Asset.
@@ -80,10 +81,10 @@
  *  @param placeholderImage An alternative image which will be displayed until `asset` is loaded.
  *  @exception NSIllegalArgumentException If the Asset is pointing to an image.
  */
--(void)cda_setImageWithPersistedAsset:(id<CDAPersistedAsset>)asset
-                               client:(CDAClient*)client
+-(void)cda_setImageWithPersistedAsset:(id<CDAPersistedAsset> __nonnull)asset
+                               client:(CDAClient* __nonnull)client
                                  size:(CGSize)size
-                     placeholderImage:(UIImage *)placeholderImage;
+                     placeholderImage:(UIImage * __nullable)placeholderImage;
 
 /** @name Use Offline Caching */
 

--- a/ContentfulDeliveryAPI.podspec
+++ b/ContentfulDeliveryAPI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files         = 'Code/*.{h,m}',
-  s.public_header_files  = 'Code/{CDAArray,CDAAsset,CDAClient,CDAConfiguration,CDAContentType,CDAEntry,CDAError,CDAField,CDARequest,CDAResource,CDAResponse,CDASpace,CDASyncedSpace,ContentfulDeliveryAPI,CDAPersistenceManager,CDAPersistedAsset,CDAPersistedEntry,CDAPersistedSpace}.h'
+  s.public_header_files  = 'Code/{CDAArray,CDAAsset,CDAClient,CDAConfiguration,CDAContentType,CDAEntry,CDAError,CDAField,CDANullabilityStubs,CDARequest,CDAResource,CDAResponse,CDASpace,CDASyncedSpace,ContentfulDeliveryAPI,CDAPersistenceManager,CDAPersistedAsset,CDAPersistedEntry,CDAPersistedSpace}.h'
 
   s.ios.deployment_target     = '6.0'
   s.ios.source_files          = 'Code/UIKit/*.{h,m}'

--- a/ContentfulSDK.xcodeproj/project.pbxproj
+++ b/ContentfulSDK.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		A173F59B18D9A2FD000E6F92 /* CDAResourceCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDAResourceCell.m; sourceTree = "<group>"; };
 		A173F60218DB3E1E000E6F92 /* PreviewModeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PreviewModeTests.m; sourceTree = "<group>"; };
 		A173F60418DB412C000E6F92 /* PreviewModeTests.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PreviewModeTests.json; path = Data/Recordings/PreviewModeTests.json; sourceTree = "<group>"; };
+		A17CC3D61ADE5F2700C7AA57 /* CDANullabilityStubs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDANullabilityStubs.h; sourceTree = "<group>"; };
 		A18AA81018E1D14F00D430D5 /* CDASyncedSpace+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CDASyncedSpace+Private.h"; sourceTree = "<group>"; };
 		A18AA81118E2D98200D430D5 /* CDADeletedEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDADeletedEntry.h; sourceTree = "<group>"; };
 		A18AA81218E2D98200D430D5 /* CDADeletedEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDADeletedEntry.m; sourceTree = "<group>"; };
@@ -705,6 +706,7 @@
 			children = (
 				A18AA85F18E5D63B00D430D5 /* CDAFallbackDictionary.h */,
 				A18AA86018E5D63B00D430D5 /* CDAFallbackDictionary.m */,
+				A17CC3D61ADE5F2700C7AA57 /* CDANullabilityStubs.h */,
 				A1A0313D18C66667006470B7 /* CDAUtilities.h */,
 				A1A0313E18C66667006470B7 /* CDAUtilities.m */,
 			);

--- a/Examples/CoreDataExample/CoreDataFetchDataSource.m
+++ b/Examples/CoreDataExample/CoreDataFetchDataSource.m
@@ -6,6 +6,7 @@
 //
 //
 
+#import "CDAUtilities.h"
 #import "CoreDataFetchDataSource.h"
 
 @interface CoreDataFetchDataSource () <NSFetchedResultsControllerDelegate>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -68,12 +68,12 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AFNetworking: fefbce9660acb17f48ae0011292d4da0f457bf36
   CCLRequestReplay: a472e52da260c28d7a41df76697b8e518625a44f
-  ContentfulDeliveryAPI: a4d72f88b97e6f7b009875fcf55e11831eb55c5d
-  FBSnapshotTestCase: e2914fbaabccea1dcc773d6a16b1c24540642488
-  ISO8601DateFormatter: 59731cd880cf87e71b4fa95f0d6b713dcbc4cbce
-  OCMock: 6db79185520e24f9f299548f2b8b07e41d881bd5
-  PDKTCollectionViewWaterfallLayout: cdde9e714973c9de67f078ba495b9d9e6812082d
-  Realm: 56fd06bf4e97da2829f864e2bca229a060825c61
-  VCRURLConnection: ad8bfbd376ad44a7f5c48358f3ee96a40d4e683e
+  ContentfulDeliveryAPI: 46b78d6b3170eeef94e467b1bbd898d84fdbe2ff
+  FBSnapshotTestCase: 26f32d8fa9eb30e9f09712ecfb097808bc79b898
+  ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
+  OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
+  PDKTCollectionViewWaterfallLayout: a246de22e843bdb2677ab2fe5d6c1fb0a623f93e
+  Realm: 0c9ee710b77cf79809c1ed85655fed9f1f887142
+  VCRURLConnection: accd771ebd4be11183a3e4d5a4403f180a9a235e
 
-COCOAPODS: 0.36.0
+COCOAPODS: 0.36.3

--- a/Tests/ClientConfiguration.m
+++ b/Tests/ClientConfiguration.m
@@ -17,7 +17,9 @@
 @implementation ClientConfiguration
 
 -(void)testDefaultUserAgent {
-    CDARequest* request = [self.client fetchEntriesWithSuccess:nil failure:nil];
+    CDARequest* request = [self.client fetchEntriesWithSuccess:^(CDAResponse *response,
+                                                                 CDAArray *array) { }
+                                                       failure:nil];
     NSString* userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
 
     XCTAssertTrue([userAgent hasPrefix:@"contentful.objc"], @"");
@@ -30,7 +32,9 @@
                                           accessToken:@"test"
                                         configuration:configuration];
 
-    CDARequest* request = [self.client fetchEntriesWithSuccess:nil failure:nil];
+    CDARequest* request = [self.client fetchEntriesWithSuccess:^(CDAResponse *response,
+                                                                 CDAArray *array) { }
+                                                       failure:nil];
     NSString* userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
 
     XCTAssertTrue([userAgent hasPrefix:@"CustomUserAgent/foo"], @"");

--- a/Tests/UIKitAdditionsTests.m
+++ b/Tests/UIKitAdditionsTests.m
@@ -377,7 +377,7 @@
 }
 
 - (void)testResourcesViewControllerDoesNotThrowWhenSelectingGarbage {
-    CDAResourcesViewController* resourcesVC = [[CDAResourcesViewController alloc] initWithCellMapping:nil items:@[ [self customEntryHelperWithFields:@{}] ]];
+    CDAResourcesViewController* resourcesVC = [[CDAResourcesViewController alloc] initWithCellMapping:@{} items:@[ [self customEntryHelperWithFields:@{}] ]];
     [resourcesVC didSelectRowWithResource:(CDAResource*)[NSDate date]];
 }
 
@@ -385,7 +385,7 @@
     CDAAsset* asset = [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"foo" },
                                                               @"contentType": @"image/png" }
                                                               client:self.client];
-    CDAResourcesViewController* resourcesVC = [[CDAResourcesViewController alloc] initWithCellMapping:nil items:@[ asset ]];
+    CDAResourcesViewController* resourcesVC = [[CDAResourcesViewController alloc] initWithCellMapping:@{} items:@[ asset ]];
     
     XCTAssertNotNil(resourcesVC.view, @"");
     [resourcesVC viewWillAppear:NO];


### PR DESCRIPTION
The `CDANullabilityStubs.h` header provides empty definitions of the
relevant symbols so that the SDK keeps being backwards compatible.