### PR TITLE
Mark +[CDASyncedSpace readFromFile:client:] as nullable. Add file URL version.

### DIFF
--- a/Code/CDASyncedSpace.h
+++ b/Code/CDASyncedSpace.h
@@ -123,7 +123,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return A new Resource initialized with values from a previously serialized synchronized Space.
  */
-+(instancetype)readFromFile:(NSString*)filePath client:(CDAClient*)client;
++(nullable instancetype)readFromFile:(NSString*)filePath client:(CDAClient*)client;
+/**
+ *  Read a previously serialized synchronized Space from file.
+ *
+ *  @param fileURL  The file URL to the file with a serialized synchronized Space.
+ *  @param client   The client to use for upcoming requests.
+ *
+ *  @return A new Resource initialized with values from a previously serialized synchronized Space.
+ */
++(nullable instancetype)readFromFileURL:(NSURL*)fileURL client:(CDAClient*)client;
 
 /**
  *  Serialize a synchronized Space to a file.

--- a/Code/CDASyncedSpace.m
+++ b/Code/CDASyncedSpace.m
@@ -29,16 +29,28 @@
 
 @implementation CDASyncedSpace
 
-+(instancetype)readFromFile:(NSString*)filePath client:(CDAClient*)client {
-    CDASyncedSpace* item = nil;
-    
-    if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
-        NSData *data = [NSData dataWithContentsOfFile:filePath];
-        item = [NSKeyedUnarchiver unarchiveObjectWithData:data];
++(nullable instancetype)readFromFile:(NSString*)filePath client:(CDAClient*)client {
+    if (filePath == nil) {
+        return nil;
     }
-    
-    item.client = client;
-    return item;
+    return [self readFromFileURL:[NSURL fileURLWithPath:filePath] client:client];
+}
++(nullable instancetype)readFromFileURL:(NSURL*)fileURL client:(CDAClient*)client {
+    if (fileURL == nil || !fileURL.isFileURL) {
+        return nil;
+    }
+    CDASyncedSpace* item = nil;
+    NSData *data = [NSData dataWithContentsOfURL:fileURL options:NSDataReadingMappedIfSafe error:nil];
+    if (data != nil) {
+        @try {
+            item = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        } @catch (id ue) {
+            return nil;
+        }
+        item.client = client;
+        return item;
+    }
+    return nil;
 }
 
 +(instancetype)shallowSyncSpaceWithToken:(NSString *)syncToken client:(CDAClient *)client {

--- a/Code/CDASyncedSpace.m
+++ b/Code/CDASyncedSpace.m
@@ -45,6 +45,7 @@
         @try {
             item = [NSKeyedUnarchiver unarchiveObjectWithData:data];
         } @catch (id ue) {
+            (void) ue;
             return nil;
         }
         item.client = client;


### PR DESCRIPTION
We're using this from Swift and will crash when `+readFromFile:client:` returns `nil` because it is currently not marked `nullable`.

Also the call to `-[NSFileManager fileExistsAtPath:]` followed by `+[NSData dataWithContentsOfFile:]` doesn't add anything. Simply trying to read from the file will return `nil` if the file is not there.

The call to `+[NSKeyedUnarchiver unarchiveObjectWithData:]` should be wrapped in a `@try` + `@catch` because it throws an exception upon error — something we can't easily catch in Swift.

Finally: Using file URLs is the way that Apple is moving with all of its API. Would be great to support that.