### PR TITLE
Fix crash inside CDAClassGetSubclasses()

### DIFF
--- a/Code/CDAUtilities.m
+++ b/Code/CDAUtilities.m
@@ -67,6 +67,7 @@ NSString* CDACacheFileNameForResource(CDAResource* resource) {
 NSArray* CDAClassGetSubclasses(Class parentClass) {
     int numClasses = objc_getClassList(NULL, 0);
     Class* classes = NULL;
+    static const Class invalidClass =  (__bridge Class) (void*) (((intptr_t) 0)-1);
     
     classes = (__unsafe_unretained Class*)malloc(sizeof(Class) * numClasses);
     numClasses = objc_getClassList(classes, numClasses);
@@ -76,9 +77,9 @@ NSArray* CDAClassGetSubclasses(Class parentClass) {
         Class superClass = classes[i];
         do {
             superClass = class_getSuperclass(superClass);
-        } while(superClass && superClass != parentClass);
+        } while(superClass && (superClass != parentClass) && (superClass != invalidClass));
         
-        if (superClass == nil) {
+        if ((superClass == nil) || (superClass == invalidClass)) {
             continue;
         }
         


### PR DESCRIPTION
We were seeing crashes where
```
(lldb) p superClass
(Class) $3 = 0xffffffffffffffff
```
inside the loop
```
        do {
            superClass = class_getSuperclass(superClass);
        } while(superClass && superClass != parentClass);
```