### PR TITLE
Hard code CDAResource subclasses in stead of querying the runtime.

### DIFF
--- a/Code/CDAAsset.m
+++ b/Code/CDAAsset.m
@@ -75,13 +75,6 @@ const CGFloat CDARadiusNone             = 0.0;
     return @"Asset";
 }
 
-+(NSArray*)subclasses {
-    static dispatch_once_t once;
-    static NSArray* subclasses;
-    dispatch_once(&once, ^ { subclasses = CDAClassGetSubclasses([self class]); });
-    return subclasses;
-}
-
 #pragma mark -
 
 -(void)cacheAssetForcingOverwrite:(BOOL)forceOverwrite

--- a/Code/CDAEntry.m
+++ b/Code/CDAEntry.m
@@ -35,13 +35,6 @@
     return @"Entry";
 }
 
-+(NSArray*)subclasses {
-    static dispatch_once_t once;
-    static NSArray* subclasses;
-    dispatch_once(&once, ^ { subclasses = CDAClassGetSubclasses([self class]); });
-    return subclasses;
-}
-
 #pragma mark -
 
 -(CLLocationCoordinate2D)CLLocationCoordinate2DFromFieldWithIdentifier:(NSString*)identifier {

--- a/Code/CDAUtilities.h
+++ b/Code/CDAUtilities.h
@@ -26,7 +26,6 @@ _Pragma("clang diagnostic pop")\
 NSString* CDACacheDirectory();
 NSString* CDACacheFileNameForQuery(CDAClient* client, CDAResourceType resourceType, NSDictionary* query);
 NSString* CDACacheFileNameForResource(CDAResource* resource);
-NSArray* CDAClassGetSubclasses(Class parentClass);
 void CDADecodeObjectWithCoder(id object, NSCoder* aDecoder);
 void CDAEncodeObjectWithCoder(id object, NSCoder* aCoder);
 BOOL CDAIsNoNetworkError(NSError* error);

--- a/Code/CDAUtilities.m
+++ b/Code/CDAUtilities.m
@@ -63,33 +63,6 @@ NSString* CDACacheFileNameForResource(CDAResource* resource) {
     return [CDACacheDirectory() stringByAppendingPathComponent:fileName];
 }
 
-// Thanks to http://www.cocoawithlove.com/2010/01/getting-subclasses-of-objective-c-class.html
-NSArray* CDAClassGetSubclasses(Class parentClass) {
-    int numClasses = objc_getClassList(NULL, 0);
-    Class* classes = NULL;
-    static const Class invalidClass =  (__bridge Class) (void*) (((intptr_t) 0)-1);
-    
-    classes = (__unsafe_unretained Class*)malloc(sizeof(Class) * numClasses);
-    numClasses = objc_getClassList(classes, numClasses);
-    
-    NSMutableArray* result = [NSMutableArray array];
-    for (NSInteger i = 0; i < numClasses; i++) {
-        Class superClass = classes[i];
-        do {
-            superClass = class_getSuperclass(superClass);
-        } while(superClass && (superClass != parentClass) && (superClass != invalidClass));
-        
-        if ((superClass == nil) || (superClass == invalidClass)) {
-            continue;
-        }
-        
-        [result addObject:classes[i]];
-    }
-    
-    free(classes);
-    return result;
-}
-
 void CDADecodeObjectWithCoder(id object, NSCoder* aDecoder) {
     CDAPropertyVisitor([object class], ^(objc_property_t property, NSString *propertyName) {
         if (!CDAIgnoreProperty(property)) {


### PR DESCRIPTION
Our top crashes happen inside `CDAClassGetSubclasses`. Since the list of subclasses is short and stable, I'd suggest going with this simple, hard-coded list.