### PR TITLE
Fix Travis

### DIFF
--- a/Tests/APICoverageTests.m
+++ b/Tests/APICoverageTests.m
@@ -102,7 +102,7 @@ typedef void(^CDAEntriesFetchBlock)(NSArray* entries);
 
 -(void)testFetchEntriesByLocationsInBoundingObject {
     [self fetchEntriesMatching:@{ @"fields.center[within]": @[@36, @-124, @40, @-120], @"content_type": @"1t9IbcfdCk6m04uISSsaIK" } success:^(NSArray *entries) {
-        XCTAssertEqual(entries.count, 0);
+        XCTAssertEqual(entries.count, 1);
     }];
 }
 

--- a/Tests/AsyncTesting.h
+++ b/Tests/AsyncTesting.h
@@ -21,7 +21,7 @@ do { \
 NSDate* __startTime = [NSDate date]; \
 while(condition) { \
 [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; \
-if ([[NSDate date] timeIntervalSinceDate:__startTime] > 10.0) { \
+if ([[NSDate date] timeIntervalSinceDate:__startTime] > 20.0) { \
 XCTAssertFalse(true, @"Asynchronous test timed out."); \
 break; \
 } \


### PR DESCRIPTION
Needed to bump the timeout, due to too many random failures. Also changes the expectation for one test that actually changed because of the Postgres migration.