### PR TITLE
Fix a potential race condition regarding localisation

### DIFF
--- a/Code/CDAArray.m
+++ b/Code/CDAArray.m
@@ -37,8 +37,10 @@
     return self.items.description;
 }
 
--(id)initWithDictionary:(NSDictionary*)dictionary client:(CDAClient*)client {
-    self = [super initWithDictionary:dictionary client:client];
+-(id)initWithDictionary:(NSDictionary*)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
+    self = [super initWithDictionary:dictionary client:client localizationAvailable:localizationAvailable];
     if (self) {
         self.limit = [dictionary[@"limit"] unsignedIntegerValue];
         self.skip = [dictionary[@"skip"] unsignedIntegerValue];
@@ -49,7 +51,9 @@
         
         NSMutableArray* items = [@[] mutableCopy];
         for (NSDictionary* item in dictionary[@"items"]) {
-            CDAResource* resource = [CDAResource resourceObjectForDictionary:item client:self.client];
+            CDAResource* resource = [CDAResource resourceObjectForDictionary:item
+                                                                      client:self.client
+                                                       localizationAvailable:localizationAvailable];
             [items addObject:resource];
         }
         self.items = [items copy];
@@ -57,7 +61,8 @@
         NSMutableArray* errors = [@[] mutableCopy];
         for (NSDictionary* item in dictionary[@"errors"]) {
             CDAError* error = (CDAError*)[CDAResource resourceObjectForDictionary:item
-                                                                           client:self.client];
+                                                                           client:self.client
+                                                            localizationAvailable:localizationAvailable];
             NSAssert(CDAClassIsOfType([error class], CDAError.class),
                      @"Invalid resource %@ in errors array.", error);
             [errors addObject:[error errorRepresentationWithCode:0]];
@@ -68,7 +73,7 @@
 }
 
 -(id)initWithItems:(NSArray *)items client:(CDAClient *)client {
-    self = [self initWithDictionary:@{ @"sys": @{} } client:client];
+    self = [self initWithDictionary:@{ @"sys": @{} } client:client localizationAvailable:NO];
     if (self) {
         self.limit = items.count;
         self.skip = 0;

--- a/Code/CDAAsset.m
+++ b/Code/CDAAsset.m
@@ -48,15 +48,12 @@ const CGFloat CDARadiusNone             = 0.0;
     
     NSDictionary* fileContent = @{ @"contentType": persistedAsset.internetMediaType,
                                    @"url": persistedAsset.url };
-    
-    if (client.localizationAvailable) {
-        fileContent = @{ client.space.defaultLocale ?: @"en-US": fileContent };
-    }
-    
+
     return [[self alloc] initWithDictionary:@{ @"sys": @{ @"id": persistedAsset.identifier,
                                                           @"type": @"Asset" },
                                                @"fields": @{ @"file": fileContent } }
-                                     client:client];
+                                     client:client
+                      localizationAvailable:NO];
 }
 
 +(NSData*)cachedDataForAsset:(CDAAsset*)asset {
@@ -249,8 +246,10 @@ const CGFloat CDARadiusNone             = 0.0;
     return [NSURL URLWithString:imageUrlString];
 }
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
-    self = [super initWithDictionary:dictionary client:client];
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
+    self = [super initWithDictionary:dictionary client:client localizationAvailable:localizationAvailable];
     if (self) {
         NSDictionary* fields = [CDAInputSanitizer sanitizeObject:dictionary[@"fields"]];
         

--- a/Code/CDAClient+Private.h
+++ b/Code/CDAClient+Private.h
@@ -19,7 +19,6 @@ extern NSString* const CMAContentTypeHeader;
 @property (nonatomic, readonly) BOOL localizationAvailable;
 @property (nonatomic, readonly) NSString* protocol;
 @property (nonatomic) NSString* resourceClassPrefix;
-@property (nonatomic) BOOL synchronizing;
 
 -(CDAConfiguration*)configuration;
 -(instancetype)copyWithSpace:(CDASpace*)space;

--- a/Code/CDAClient.m
+++ b/Code/CDAClient.m
@@ -410,7 +410,7 @@ NSString* const CMAContentTypeHeader = @"application/vnd.contentful.management.v
 }
 
 -(BOOL)localizationAvailable {
-    return self.configuration.usesManagementAPI || self.synchronizing;
+    return self.configuration.usesManagementAPI;
 }
 
 -(CDARequest *)postURLPath:(NSString *)URLPath

--- a/Code/CDAContentType.m
+++ b/Code/CDAContentType.m
@@ -46,8 +46,10 @@
     return self.allFields[identifier];
 }
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
-    self = [super initWithDictionary:dictionary client:client];
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
+    self = [super initWithDictionary:dictionary client:client localizationAvailable:localizationAvailable];
     if (self) {
         if (dictionary[@"name"]) {
             NSString* name = dictionary[@"name"];
@@ -64,7 +66,8 @@
         
         for (NSDictionary* field in dictionary[@"fields"]) {
             CDAField* fieldObject = [[[self.class fieldClass] alloc] initWithDictionary:field
-                                                                                 client:self.client];
+                                                                                 client:self.client
+                                                                  localizationAvailable:localizationAvailable];
             
             allFields[fieldObject.identifier] = fieldObject;
             [fields addObject:fieldObject];

--- a/Code/CDAEntry.m
+++ b/Code/CDAEntry.m
@@ -100,14 +100,18 @@
     return [self findUnresolvedResourceOfClass:[CDAEntry class]];
 }
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
-    self = [super initWithDictionary:dictionary client:client];
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
+    self = [super initWithDictionary:dictionary client:client localizationAvailable:localizationAvailable];
     if (self && self.fetched) {
         NSAssert(self.contentType, @"Content-Type needs to be available.");
         
         Class customClass = [self.client.contentTypeRegistry customClassForContentType:self.contentType];
         if (customClass && customClass != [self class]) {
-            return [[customClass alloc] initWithDictionary:dictionary client:client];
+            return [[customClass alloc] initWithDictionary:dictionary
+                                                    client:client
+                                     localizationAvailable:localizationAvailable];
         }
         
         NSDictionary* fields = dictionary[@"fields"];

--- a/Code/CDAError.m
+++ b/Code/CDAError.m
@@ -45,8 +45,10 @@ NSString* const CDAErrorDomain = @"CDAErrorDomain";
                                                NSLocalizedDescriptionKey: self.message ?: @"" }];
 }
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
-    self = [super initWithDictionary:dictionary client:client];
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
+    self = [super initWithDictionary:dictionary client:client localizationAvailable:localizationAvailable];
     if (self) {
         self.details = dictionary[@"details"];
         self.message = dictionary[@"message"];

--- a/Code/CDAField+Private.h
+++ b/Code/CDAField+Private.h
@@ -15,7 +15,9 @@
 @property (nonatomic) NSString* name;
 @property (nonatomic) CDAFieldType type;
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client;
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable;
 -(id)parseValue:(id)value;
 
 @end

--- a/Code/CDAField.m
+++ b/Code/CDAField.m
@@ -136,7 +136,9 @@
     return self;
 }
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
     self = [super init];
     if (self) {
         NSParameterAssert(client);
@@ -165,7 +167,9 @@
         self.localized = [dictionary[@"localized"] boolValue];
         self.required = [dictionary[@"required"] boolValue];
         
-        self.transformer = [CDAFieldValueTransformer transformerOfType:self.type client:self.client];
+        self.transformer = [CDAFieldValueTransformer transformerOfType:self.type
+                                                                client:self.client
+                                                 localizationAvailable:localizationAvailable];
         self.transformer.itemType = self.itemType;
     }
     return self;

--- a/Code/CDAFieldValueTransformer.h
+++ b/Code/CDAFieldValueTransformer.h
@@ -14,6 +14,8 @@
 
 @property (nonatomic) CDAFieldType itemType;
 
-+(instancetype)transformerOfType:(CDAFieldType)type client:(CDAClient*)client;
++(instancetype)transformerOfType:(CDAFieldType)type
+                          client:(CDAClient*)client
+           localizationAvailable:(BOOL)localizationAvailable;
 
 @end

--- a/Code/CDAFieldValueTransformer.m
+++ b/Code/CDAFieldValueTransformer.m
@@ -18,6 +18,7 @@
 @interface CDAFieldValueTransformer ()
 
 @property (nonatomic, weak) CDAClient* client;
+@property (nonatomic) BOOL localizationAvailable;
 @property (nonatomic) CDAFieldType type;
 
 @end
@@ -30,13 +31,17 @@
     return NO;
 }
 
-+(instancetype)transformerOfType:(CDAFieldType)type client:(CDAClient*)client {
-    return [[[self class] alloc] initWithType:type client:client];
++(instancetype)transformerOfType:(CDAFieldType)type
+                          client:(CDAClient*)client
+           localizationAvailable:(BOOL)localizationAvailable {
+    return [[[self class] alloc] initWithType:type client:client localizationAvailable:localizationAvailable];
 }
 
 #pragma mark -
 
--(id)initWithType:(CDAFieldType)type client:(CDAClient*)client {
+-(id)initWithType:(CDAFieldType)type
+           client:(CDAClient*)client
+localizationAvailable:(BOOL)localizationAvailable {
     self = [super init];
     if (self) {
         NSParameterAssert(client);
@@ -59,7 +64,8 @@
 
 -(id)transformArrayValue:(id)arrayValue {
     CDAFieldValueTransformer* transformer = [CDAFieldValueTransformer transformerOfType:self.itemType
-                                                                                 client:self.client];
+                                                                                 client:self.client
+                                                                  localizationAvailable:self.localizationAvailable];
     
     NSMutableArray* array = [@[] mutableCopy];
     for (id value in arrayValue) {
@@ -109,7 +115,9 @@
                 return nil;
             }
             
-            return [CDAResource resourceObjectForDictionary:value client:self.client];
+            return [CDAResource resourceObjectForDictionary:value
+                                                     client:self.client
+                                      localizationAvailable:self.localizationAvailable];
             
         case CDAFieldTypeLocation:
             if (value == [NSNull null]) {

--- a/Code/CDAResource+Private.h
+++ b/Code/CDAResource+Private.h
@@ -13,16 +13,18 @@
 @interface CDAResource ()
 
 @property (nonatomic, weak) CDAClient* client;
-@property (nonatomic) NSString* defaultLocaleOfSpace;
-@property (nonatomic, readonly) BOOL localizationAvailable;
+@property (nonatomic) NSString* defaultLocaleOfSpace; // FIXME: should this be `readonly`?
 
 +(NSString*)CDAType;
 +(BOOL)classIsOfType:(Class)class;
-+(instancetype)resourceObjectForDictionary:(NSDictionary*)dictionary client:(CDAClient*)client;
++(instancetype)resourceObjectForDictionary:(NSDictionary*)dictionary
+                                    client:(CDAClient*)client
+                     localizationAvailable:(BOOL)localizationAvailable;
 
 -(BOOL)createdAfterDate:(NSDate*)date;
--(id)initWithDictionary:(NSDictionary*)dictionary client:(CDAClient*)client;
--(BOOL)localizationAvailable;
+-(id)initWithDictionary:(NSDictionary*)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable;
 -(NSDictionary*)localizeFieldsFromDictionary:(NSDictionary*)fields;
 -(NSDictionary*)localizedDictionaryFromDictionary:(NSDictionary*)dictionary forLocale:(NSString*)locale;
 -(NSDictionary*)parseDictionary:(NSDictionary*)dictionary;

--- a/Code/CDAResource.m
+++ b/Code/CDAResource.m
@@ -46,6 +46,7 @@ static const typeToClassMap_t typeToClassMap[] = {
 
 @property (nonatomic, readonly) BOOL isLink;
 @property (nonatomic) NSDate* lastFetchedDate;
+@property (nonatomic) BOOL localizationAvailable;
 @property (nonatomic) NSDictionary* sys;
 
 @end
@@ -69,7 +70,9 @@ static const typeToClassMap_t typeToClassMap[] = {
     return CDAReadItemFromFileURL(fileURL, client);
 }
 
-+(instancetype)resourceObjectForDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
++(instancetype)resourceObjectForDictionary:(NSDictionary *)dictionary
+                                    client:(CDAClient*)client
+                     localizationAvailable:(BOOL)localizationAvailable {
     if (![dictionary isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
@@ -97,7 +100,10 @@ static const typeToClassMap_t typeToClassMap[] = {
             }
 
             if ([[[subclass CDAType] lowercaseString] isEqualToString:resourceType]) {
-                return [self resourceObjectForSubclass:subclass dictionary:dictionary client:client];
+                return [self resourceObjectForSubclass:subclass
+                                            dictionary:dictionary
+                                                client:client
+                                 localizationAvailable:localizationAvailable];
             }
         }
     } else {
@@ -107,7 +113,10 @@ static const typeToClassMap_t typeToClassMap[] = {
             if ([name isEqualToString:resourceType]) {
                 NSString * const className = (__bridge id) typeToClassMap[i].className;
                 Class const subclass = NSClassFromString(className);
-                return [self resourceObjectForSubclass:subclass dictionary:dictionary client:client];
+                return [self resourceObjectForSubclass:subclass
+                                            dictionary:dictionary
+                                                client:client
+                                 localizationAvailable:localizationAvailable];
             }
         }
     }
@@ -118,8 +127,11 @@ static const typeToClassMap_t typeToClassMap[] = {
 
 +(instancetype)resourceObjectForSubclass:(Class)subclass
                               dictionary:(NSDictionary *)dictionary
-                                  client:(CDAClient *)client {
-    CDAResource* resource = [[subclass alloc] initWithDictionary:dictionary client:client];
+                                  client:(CDAClient *)client
+                   localizationAvailable:(BOOL)localizationAvailable {
+    CDAResource* resource = [[subclass alloc] initWithDictionary:dictionary
+                                                          client:client
+                                           localizationAvailable:localizationAvailable];
     if (!resource.fetched && client.configuration.filterNonExistingResources) {
         return nil;
     }
@@ -173,7 +185,9 @@ static const typeToClassMap_t typeToClassMap[] = {
     return self;
 }
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
     self = [super init];
     if (self) {
         self.defaultLocaleOfSpace = @"en-US";
@@ -182,6 +196,7 @@ static const typeToClassMap_t typeToClassMap[] = {
 
         NSParameterAssert(client);
         self.client = client;
+        self.localizationAvailable = localizationAvailable;
     }
     return self;
 }
@@ -207,11 +222,6 @@ static const typeToClassMap_t typeToClassMap[] = {
 
 -(BOOL)isLink {
     return [self.sys[@"type"] isEqualToString:@"Link"];
-}
-
-
--(BOOL)localizationAvailable {
-    return self.client.localizationAvailable;
 }
 
 -(NSDictionary*)localizeFieldsFromDictionary:(NSDictionary*)fields {
@@ -327,7 +337,9 @@ static const typeToClassMap_t typeToClassMap[] = {
         }
 
         if ([key isEqualToString:@"space"]) {
-            CDASpace* space = [[CDASpace alloc] initWithDictionary:value client:client];
+            CDASpace* space = [[CDASpace alloc] initWithDictionary:value
+                                                            client:client
+                                             localizationAvailable:NO];
             systemProperties[key] = space;
         }
     }];

--- a/Code/CDAResponseSerializer.m
+++ b/Code/CDAResponseSerializer.m
@@ -131,17 +131,21 @@
         return nil;
     }
     
-    self.client.synchronizing = JSONObject[@"nextPageUrl"] || JSONObject[@"nextSyncUrl"] || [CDAValueForQueryParameter(response.URL, @"locale") isEqualToString:@"*"];
+    BOOL localizationAvailable = JSONObject[@"nextPageUrl"] || JSONObject[@"nextSyncUrl"] || [CDAValueForQueryParameter(response.URL, @"locale") isEqualToString:@"*"] || self.client.localizationAvailable;
     
     NSMutableDictionary* assets = [@{} mutableCopy];
     for (NSDictionary* possibleAsset in JSONObject[@"includes"][@"Asset"]) {
-        CDAAsset* asset = [[CDAAsset alloc] initWithDictionary:possibleAsset client:self.client];
+        CDAAsset* asset = [[CDAAsset alloc] initWithDictionary:possibleAsset
+                                                        client:self.client
+                                         localizationAvailable:localizationAvailable];
         assets[asset.identifier] = asset;
     }
     
     NSMutableDictionary* entries = [@{} mutableCopy];
     for (NSDictionary* possibleEntry in JSONObject[@"includes"][@"Entry"]) {
-        CDAEntry* entry = [[CDAEntry alloc] initWithDictionary:possibleEntry client:self.client];
+        CDAEntry* entry = [[CDAEntry alloc] initWithDictionary:possibleEntry
+                                                        client:self.client
+                                         localizationAvailable:localizationAvailable];
         [entry resolveLinksWithIncludedAssets:assets entries:nil];
         entries[entry.identifier] = entry;
     }
@@ -149,12 +153,15 @@
     NSMutableArray* organizations = [@[] mutableCopy];
     for (NSDictionary* possibleOrganization in JSONObject[@"includes"][@"Organization"]) {
         CDAResource* resource = [CDAResource resourceObjectForDictionary:possibleOrganization
-                                                                  client:self.client];
+                                                                  client:self.client
+                                                   localizationAvailable:localizationAvailable];
         [organizations addObject:resource];
     }
     
     NSAssert([JSONObject isKindOfClass:[NSDictionary class]], @"JSON result is not a dictionary");
-    CDAResource* resource = [CDAResource resourceObjectForDictionary:JSONObject client:self.client];
+    CDAResource* resource = [CDAResource resourceObjectForDictionary:JSONObject
+                                                              client:self.client
+                                               localizationAvailable:localizationAvailable];
     
     if (CDAClassIsOfType([resource class], CDAArray.class)) {
         for (CDAResource* subResource in [(CDAArray*)resource items]) {

--- a/Code/CDASpace.m
+++ b/Code/CDASpace.m
@@ -25,8 +25,10 @@
 
 #pragma mark -
 
--(id)initWithDictionary:(NSDictionary *)dictionary client:(CDAClient*)client {
-    self = [super initWithDictionary:dictionary client:client];
+-(id)initWithDictionary:(NSDictionary *)dictionary
+                 client:(CDAClient*)client
+  localizationAvailable:(BOOL)localizationAvailable {
+    self = [super initWithDictionary:dictionary client:client localizationAvailable:localizationAvailable];
     if (self) {
         self.defaultLocale = @"en-US";
         self.locales = dictionary[@"locales"];

--- a/Tests/ContentfulBaseTestCase.m
+++ b/Tests/ContentfulBaseTestCase.m
@@ -137,7 +137,7 @@ extern void __gcov_flush();
 {
     NSData* spaceData = [NSData dataWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"space" ofType:@"json" inDirectory:@"SyncTests"]];
     NSDictionary* spaceJSON = [NSJSONSerialization JSONObjectWithData:spaceData options:0 error:nil];
-    CDASpace* space = [[CDASpace alloc] initWithDictionary:spaceJSON client:self.client];
+    CDASpace* space = [[CDASpace alloc] initWithDictionary:spaceJSON client:self.client localizationAvailable:NO];
     [self.client setSpace:space];
     
     NSDictionary* ct = @{
@@ -157,7 +157,7 @@ extern void __gcov_flush();
                          @"sys": @{ @"id": @"trolololo" },
                          };
     
-    CDAContentType* contentType = [[CDAContentType alloc] initWithDictionary:ct client:self.client];
+    CDAContentType* contentType = [[CDAContentType alloc] initWithDictionary:ct client:self.client localizationAvailable:NO];
     XCTAssertEqual(9U, contentType.fields.count, @"");
     
     NSDictionary* entry = @{
@@ -167,7 +167,7 @@ extern void __gcov_flush();
                                     @"contentType": @{ @"sys": @{ @"id": @"trolololo" } }
                                     },
                             };
-    CDAEntry* brokenEntry = [[CDAEntry alloc] initWithDictionary:entry client:self.client];
+    CDAEntry* brokenEntry = [[CDAEntry alloc] initWithDictionary:entry client:self.client localizationAvailable:NO];
     XCTAssertEqualObjects(@"brokenEntry", brokenEntry.identifier, @"");
     return brokenEntry;
 }

--- a/Tests/ErrorTests.m
+++ b/Tests/ErrorTests.m
@@ -265,7 +265,8 @@
                                        };
     
     CDAAsset* brokenAsset = [[CDAAsset alloc] initWithDictionary:assetDictionary
-                                                          client:[CDAClient new]];
+                                                          client:[CDAClient new]
+                                           localizationAvailable:NO];
     
     XCTAssertEqualObjects(@"my_id", brokenAsset.identifier, @"");
     XCTAssertNil(brokenAsset.fields[@"description"], @"");
@@ -306,7 +307,7 @@
                          @"sys": @{ @"id": @"6749332", @"type": @"ContentType" },
                          };
 
-    CDAContentType* brokenContentType = (CDAContentType*)[CDAResource resourceObjectForDictionary:ct client:self.client];
+    CDAContentType* brokenContentType = (CDAContentType*)[CDAResource resourceObjectForDictionary:ct client:self.client localizationAvailable:NO];
     XCTAssertNotNil(brokenContentType);
 }
 

--- a/Tests/LinkTests.m
+++ b/Tests/LinkTests.m
@@ -18,7 +18,7 @@
 @implementation LinkTests
 
 -(void)testResolveArrayOfLinks {
-    NSArray* assetArray = @[ [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"nyancat", @"type": @"Link" } } client:self.client], [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"happycat", @"type": @"Link" } } client:self.client] ];
+    NSArray* assetArray = @[ [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"nyancat", @"type": @"Link" } } client:self.client localizationAvailable:NO], [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"happycat", @"type": @"Link" } } client:self.client localizationAvailable:NO] ];
     
     for (CDAAsset* asset in assetArray) {
         XCTAssertFalse(asset.fetched, @"");
@@ -49,7 +49,8 @@
 -(void)testResolveAssetLink {
     CDAAsset* asset = [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"nyancat",
                                                                          @"type": @"Link" } }
-                                                    client:self.client];
+                                                    client:self.client
+                                     localizationAvailable:NO];
     XCTAssertFalse(asset.fetched, @"");
     XCTAssertNil(asset.URL, @"");
     
@@ -79,7 +80,7 @@
 }
 
 -(void)testResolveContentTypeLink {
-    CDAContentType* contentType = [[CDAContentType alloc] initWithDictionary:@{ @"sys": @{ @"id": @"cat", @"type": @"Link" }, @"name": @"ct" } client:self.client];
+    CDAContentType* contentType = [[CDAContentType alloc] initWithDictionary:@{ @"sys": @{ @"id": @"cat", @"type": @"Link" }, @"name": @"ct" } client:self.client localizationAvailable:NO];
     XCTAssertFalse(contentType.fetched, @"");
     XCTAssertEqual(0U, contentType.fields.count, @"");
     
@@ -112,7 +113,8 @@
 -(void)testResolveEntry {
     CDAEntry* entry = [[CDAEntry alloc] initWithDictionary:@{ @"sys": @{ @"id": @"nyancat",
                                                                          @"type": @"Link" } }
-                                                    client:self.client];
+                                                    client:self.client
+                                     localizationAvailable:NO];
     XCTAssertFalse(entry.fetched, @"");
     XCTAssertEqual(0U, entry.fields.count, @"");
     
@@ -147,7 +149,8 @@
 -(void)testResolveResource {
     CDAResource* resource = [[CDAResource alloc] initWithDictionary:@{ @"sys": @{ @"id": @"nyancat",
                                                                                   @"type": @"Entry" } }
-                                                             client:self.client];
+                                                             client:self.client
+                                              localizationAvailable:NO];
     
     StartBlock();
     
@@ -165,7 +168,8 @@
 -(void)testUnimplementedResolveThrows {
     CDAResource* resource = [[CDAResource alloc] initWithDictionary:@{ @"sys": @{ @"id": @"nyancat",
                                                                                   @"type": @"Link" } }
-                                                             client:self.client];
+                                                             client:self.client
+                                              localizationAvailable:NO];
     
     XCTAssertThrowsSpecificNamed([resource resolveWithSuccess:^(CDAResponse* a, CDAResource* b) {
     } failure:^(CDAResponse* a, NSError* b) {}], NSException, NSInternalInconsistencyException, @"");

--- a/Tests/SyncBaseTestCase.m
+++ b/Tests/SyncBaseTestCase.m
@@ -32,8 +32,8 @@
 @implementation SyncBaseTestCase
 
 -(void)addDummyContentType {
-    CDAContentType* ct = [[CDAContentType alloc] initWithDictionary:@{ @"sys": @{ @"id": @"6bAvxqodl6s4MoKuWYkmqe" }, @"name": @"Stub", @"fields": @[ @{ @"id": @"title", @"type": @"Symbol" }, @{ @"id": @"body", @"type": @"Text" }, @{ @"id": @"category", @"type": @"Link" }, @{ @"id": @"picture", @"type": @"Link" } ] } client:self.client];
-    ct = [[CDAContentType alloc] initWithDictionary:@{ @"sys": @{ @"id": @"51LZmvenywOe8aig28sCgY" }, @"name": @"OtherStub", @"fields": @[ @{ @"id": @"name", @"type": @"Symbol" } ], } client:self.client];
+    CDAContentType* ct = [[CDAContentType alloc] initWithDictionary:@{ @"sys": @{ @"id": @"6bAvxqodl6s4MoKuWYkmqe" }, @"name": @"Stub", @"fields": @[ @{ @"id": @"title", @"type": @"Symbol" }, @{ @"id": @"body", @"type": @"Text" }, @{ @"id": @"category", @"type": @"Link" }, @{ @"id": @"picture", @"type": @"Link" } ] } client:self.client localizationAvailable:NO];
+    ct = [[CDAContentType alloc] initWithDictionary:@{ @"sys": @{ @"id": @"51LZmvenywOe8aig28sCgY" }, @"name": @"OtherStub", @"fields": @[ @{ @"id": @"name", @"type": @"Symbol" } ], } client:self.client localizationAvailable:NO];
 }
 
 -(CDAClient*)buildClient {

--- a/Tests/UIKitAdditionsTests.m
+++ b/Tests/UIKitAdditionsTests.m
@@ -384,7 +384,8 @@
 - (void)testResourcesViewControllerShowsImageViewControllerForAssets {
     CDAAsset* asset = [[CDAAsset alloc] initWithDictionary:@{ @"sys": @{ @"id": @"foo" },
                                                               @"contentType": @"image/png" }
-                                                              client:self.client];
+                                                    client:self.client
+                                     localizationAvailable:NO];
     CDAResourcesViewController* resourcesVC = [[CDAResourcesViewController alloc] initWithCellMapping:@{} items:@[ asset ]];
     
     XCTAssertNotNil(resourcesVC.view, @"");

--- a/Tests/UtilityTests.m
+++ b/Tests/UtilityTests.m
@@ -81,7 +81,8 @@
     CDAClient* client = [CDAClient new];
     [client fetchSpaceWithSuccess:^(CDAResponse *response, CDASpace *space) {
         CDAResource* resource = [CDAResource resourceObjectForDictionary:@{ @"sys": @{ @"id": @"foo", @"type": @"Asset" }, @"fields": @{ @"file": @{ @"url": @"file:///test/test.foo" } } }
-                                                                  client:client];
+                                                                  client:client
+                                                   localizationAvailable:NO];
         NSString* cacheFileName = CDACacheFileNameForResource(resource);
         [self assertCacheFile:cacheFileName againstSuffix:@"com.contentful.sdk/cache_cfexampleapi_Asset_foo.foo"];
         
@@ -110,10 +111,10 @@
     client.resourceClassPrefix = @"YOLO";
     NSDictionary* dummyPayload = @{ @"sys": @{ @"id": @"06f5086772e0cd0b8f4e2381fa610d36" },
                                     @"name": @"yolo" };
-    CDAContentType* dummyCT = [[CDAContentType alloc] initWithDictionary:dummyPayload client:self.client];
+    CDAContentType* dummyCT = [[CDAContentType alloc] initWithDictionary:dummyPayload client:self.client localizationAvailable:NO];
     [client registerClass:CDAEntry.class forContentType:dummyCT];
 
-    CDASpace* space = [[CDASpace alloc] initWithDictionary:dummyPayload client:self.client];
+    CDASpace* space = [[CDASpace alloc] initWithDictionary:dummyPayload client:self.client localizationAvailable:NO];
     CDAClient* copiedClient = [client copyWithSpace:space];
 
     XCTAssertEqual(copiedClient.resourceClassPrefix, @"YOLO");


### PR DESCRIPTION
Prior to this PR, the localisation flag existed on the client object and resources were querying it. This leaves up the potential for subsequent operations to change the flag before all resources which depend on it have been fully processed. This change injects the localisation flag at construction time instead, so that it is immutable for a given resource.