### PR TITLE
Update/Fix CDAFieldValueTransformer.m

### DIFF
--- a/Code/CDAFieldValueTransformer.m
+++ b/Code/CDAFieldValueTransformer.m
@@ -70,7 +70,9 @@ localizationAvailable:(BOOL)localizationAvailable {
     NSMutableArray* array = [@[] mutableCopy];
     for (id value in arrayValue) {
         id transformedValue = [transformer transformedValue:value];
-        [array addObject:transformedValue];
+        if(transformedValue) {
+            [array addObject:transformedValue];
+        }
     }
     
     return [array copy];


### PR DESCRIPTION
The line `[array addObject:transformedValue];` needs to be modified to verify that `transformedValue` is not nil.  The line above invokes `-(id)transformedValue:(id)value` which has several returns that could be nil.

Per Apples documentation linked below arguments for the instance method `-addObject:` of NSMutableArray must not be nil.
https://developer.apple.com/reference/foundation/nsmutablearray/1411274-addobject?language=objc
