### PR TITLE
Bugfix/invalid pod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: objective-c
 git:
   depth: 50
   submodules: false # Manually manage submodules so we can swap ssh with http
+cache:
+- bundler
+- cocoapods
 matrix:
   include:
     - osx_image: xcode8.2
@@ -17,6 +20,7 @@ before_install:
 - git submodule update --init --recursive
 - gem install bundler
 - bundle install
+- pod repo update --silent
 script:
 - ./scripts/travis-build-test.sh
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,15 @@ before_install:
 - git config --file=.gitmodules submodule.Submodules/ContentfulPersistence.url https://github.com/contentful/contentful-persistence.objc.git
 - git submodule sync
 - git submodule update --init --recursive
-- gem install bundler
+
+# Projects with a Gemfile automatically run `bundle install` on travis
+# and subsequently `bundle exec pod install`, but we need to
+# update the pod specs repo first. Therefore, we override `install` to prevent
+# `bundle install` from running twice
+install:
 - bundle install
-- pod repo update --silent
+- bundle exec pod repo update --silent
+- bundle exec pod install
 script:
 - ./scripts/travis-build-test.sh
 notifications:

--- a/Code/CDAFieldValueTransformer.m
+++ b/Code/CDAFieldValueTransformer.m
@@ -8,8 +8,7 @@
 
 @import MapKit;
 
-#import <ISO8601DateFormatter/ISO8601DateFormatter.h>
-
+#import <ISO8601/ISO8601.h>
 #import "CDAClient+Private.h"
 #import "CDAFieldValueTransformer.h"
 #import "CDAResource+Private.h"
@@ -92,7 +91,7 @@ localizationAvailable:(BOOL)localizationAvailable {
                 return nil;
             }
             
-            return [[ISO8601DateFormatter new] dateFromString:value];
+            return [NSDate dateWithISO8601String:value];
             
         case CDAFieldTypeBoolean:
         case CDAFieldTypeInteger:

--- a/Code/CDAResource.m
+++ b/Code/CDAResource.m
@@ -12,7 +12,7 @@
 #import <ContentfulDeliveryAPI/CDAContentType.h>
 #import <ContentfulDeliveryAPI/CDAResource.h>
 #import <ContentfulDeliveryAPI/CDASpace.h>
-#import <ISO8601DateFormatter/ISO8601DateFormatter.h>
+#import <ISO8601/ISO8601.h>
 
 #import "CDAClient+Private.h"
 #import "CDAContentTypeRegistry.h"
@@ -296,7 +296,6 @@ static const typeToClassMap_t typeToClassMap[] = {
 }
 
 -(void)updateWithContentsOfDictionary:(NSDictionary*)dictionary client:(CDAClient*)client {
-    ISO8601DateFormatter* dateFormatter = [ISO8601DateFormatter new];
     NSMutableDictionary* systemProperties = [@{} mutableCopy];
 
     NSAssert(dictionary[@"sys"], @"A resource needs system properties");
@@ -315,7 +314,7 @@ static const typeToClassMap_t typeToClassMap[] = {
         }
 
         if ([@[ @"createdAt", @"updatedAt" ] containsObject:key]) {
-            NSDate* date = [dateFormatter dateFromString:value];
+            NSDate* date = [NSDate dateWithISO8601String:value];
             NSAssert(date, @"createdAt, updatedAt needs to be a valid date");
             systemProperties[key] = date;
         }

--- a/ContentfulDeliveryAPI.podspec
+++ b/ContentfulDeliveryAPI.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target     = '10.10'
 
   s.dependency 'AFNetworking', '~> 3.1.0'
-  s.dependency 'ISO8601DateFormatter', '0.8'
+  s.dependency 'ISO8601', '~> 0.6.0'
+
 end
 

--- a/ContentfulSDK.xcodeproj/project.pbxproj
+++ b/ContentfulSDK.xcodeproj/project.pbxproj
@@ -246,9 +246,9 @@
 		ED31CEDF1E534E43007C8E48 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED31CEDE1E534E43007C8E48 /* CoreData.framework */; };
 		ED31CEE21E534E85007C8E48 /* libContentfulDeliveryAPI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A19FD86718C631E60081677E /* libContentfulDeliveryAPI.a */; };
 		ED31CEE41E534E92007C8E48 /* libAFNetworking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED31CEE31E534E92007C8E48 /* libAFNetworking.a */; };
-		ED31CEE61E534EA3007C8E48 /* libISO8601DateFormatter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED31CEE51E534EA3007C8E48 /* libISO8601DateFormatter.a */; };
 		ED31CEEA1E534EBF007C8E48 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED31CEE91E534EBF007C8E48 /* UIKit.framework */; };
 		ED31CEEC1E534ED9007C8E48 /* libPods-CDA Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED31CEEB1E534ED9007C8E48 /* libPods-CDA Tests.a */; };
+		ED4AD4B71E5CA3F60049B8D4 /* libISO8601.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED4AD4B61E5CA3F60049B8D4 /* libISO8601.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -601,6 +601,7 @@
 		ED31CEE51E534EA3007C8E48 /* libISO8601DateFormatter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libISO8601DateFormatter.a; path = "../../../../Library/Developer/Xcode/DerivedData/ContentfulSDK-dqokadybfwzbxycecawequgzwmcs/Build/Products/Debug-iphonesimulator/ISO8601DateFormatter/libISO8601DateFormatter.a"; sourceTree = "<group>"; };
 		ED31CEE91E534EBF007C8E48 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		ED31CEEB1E534ED9007C8E48 /* libPods-CDA Tests.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-CDA Tests.a"; path = "../../../../Library/Developer/Xcode/DerivedData/ContentfulSDK-dqokadybfwzbxycecawequgzwmcs/Build/Products/Debug-iphonesimulator/libPods-CDA Tests.a"; sourceTree = "<group>"; };
+		ED4AD4B61E5CA3F60049B8D4 /* libISO8601.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libISO8601.a; path = "Pods/../build/Debug-iphoneos/ISO8601/libISO8601.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -628,8 +629,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED4AD4B71E5CA3F60049B8D4 /* libISO8601.a in Frameworks */,
 				ED31CEEC1E534ED9007C8E48 /* libPods-CDA Tests.a in Frameworks */,
-				ED31CEE61E534EA3007C8E48 /* libISO8601DateFormatter.a in Frameworks */,
 				ED31CEE41E534E92007C8E48 /* libAFNetworking.a in Frameworks */,
 				ED31CEE21E534E85007C8E48 /* libContentfulDeliveryAPI.a in Frameworks */,
 				ED31CEDF1E534E43007C8E48 /* CoreData.framework in Frameworks */,
@@ -867,6 +868,7 @@
 		A19FD86918C631E60081677E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				ED4AD4B61E5CA3F60049B8D4 /* libISO8601.a */,
 				ED31CEEB1E534ED9007C8E48 /* libPods-CDA Tests.a */,
 				ED31CEE91E534EBF007C8E48 /* UIKit.framework */,
 				ED31CEE51E534EA3007C8E48 /* libISO8601DateFormatter.a */,
@@ -2460,6 +2462,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos/ISO8601",
+				);
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.contentful.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2510,6 +2516,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos/ISO8601",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.contentful.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -3028,6 +3038,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos/ISO8601",
+				);
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.contentful.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,8 +26,8 @@ PODS:
   - CCLRequestReplay/Record (0.9.0)
   - CCLRequestReplay/Replay (0.9.0)
   - FBSnapshotTestCase/Core (2.1.4)
-  - ISO8601DateFormatter (0.8)
-  - OCMock (3.3.1)
+  - ISO8601 (0.6.0)
+  - OCMock (3.4)
   - PDKTCollectionViewWaterfallLayout (0.1)
   - Realm (0.98.8):
     - Realm/Headers (= 0.98.8)
@@ -38,7 +38,7 @@ DEPENDENCIES:
   - AFNetworking (~> 3.1.0)
   - CCLRequestReplay (from `https://github.com/neonichu/CCLRequestReplay.git`)
   - FBSnapshotTestCase/Core
-  - ISO8601DateFormatter (= 0.8)
+  - ISO8601 (~> 0.6.0)
   - OCMock
   - PDKTCollectionViewWaterfallLayout
   - Realm (= 0.98.8)
@@ -57,8 +57,8 @@ SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   CCLRequestReplay: a472e52da260c28d7a41df76697b8e518625a44f
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
-  OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
+  ISO8601: d3ea3ba9b752820cf92c6b47a9ee327e9f0e13fc
+  OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   PDKTCollectionViewWaterfallLayout: a246de22e843bdb2677ab2fe5d6c1fb0a623f93e
   Realm: 0e293bb62999730599efc3048896bbd4f2e43bcd
   VCRURLConnection: 1b14489604ca90b7b144b50dab6f9845d8931a45

--- a/Tests/SearchAPITests.m
+++ b/Tests/SearchAPITests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <ISO8601DateFormatter/ISO8601DateFormatter.h>
+#import <ISO8601/ISO8601.h>
 
 #import "ContentfulBaseTestCase.h"
 
@@ -164,7 +164,7 @@
 - (void)testDateRangeSearch {
     StartBlock();
     
-    NSDate* date = [[ISO8601DateFormatter new] dateFromString:@"2013-01-01T00:00:00Z"];
+    NSDate* date = [NSDate dateWithISO8601String:@"2013-01-01T00:00:00Z"];
     
     [self.client fetchEntriesMatching:@{ @"sys.updatedAt[gte]": date }
         success:^(CDAResponse *response, CDAArray *array) {


### PR DESCRIPTION
Opt for a new date formatting dependency that is more recently maintained, and additionally that doesn't invalidate the podspec by using deprecated Cocoa API.