### PR TITLE
Fix layout engine background access

### DIFF
--- a/Code/UIKit/UIImageView+CDAAsset.m
+++ b/Code/UIKit/UIImageView+CDAAsset.m
@@ -130,14 +130,18 @@ static NSCache* cache = nil;
         }
         self.requestURL_cda = nil;
 
-        [self hideActivityIndicator];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self hideActivityIndicator];
+        });
 
         if (!data) {
             NSLog(@"Error while request '%@': %@", response.URL, error);
             return;
         }
 
-        self.image = [UIImage imageWithData:(NSData * _Nonnull)data];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.image = [UIImage imageWithData:(NSData * _Nonnull)data];
+        });
         [self cda_handleCachingForAsset:asset];
     }] resume];
 }


### PR DESCRIPTION
Added main queue dispatch to fix warning included below.  Added second main queue dispatch to ensure image is drawn when intended.  Without dispatch image is drawn on next arbitrary view redraw.

> This application is modifying the autolayout engine from a background thread after the engine was accessed from the main thread. This can lead to engine corruption and weird crashes.
 Stack:(
	0   CoreFoundation                      0x000000010a6b0d4b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x000000010b84621e objc_exception_throw + 48
	2   CoreFoundation                      0x000000010a71a2b5 +[NSException raise:format:] + 197
	3   Foundation                          0x000000010b54006c _AssertAutolayoutOnAllowedThreadsOnly + 180
	4   Foundation                          0x000000010b361334 -[NSISEngine withBehaviors:performModifications:] + 31
	5   UIKit                               0x000000010c4d2ef3 -[UIView(Hierarchy) _postMovedFromSuperview:] + 884
	6   UIKit                               0x000000010c4d0b52 __UIViewWasRemovedFromSuperview + 172
	7   UIKit                               0x000000010c4d0649 -[UIView(Hierarchy) removeFromSuperview] + 574
	8   ContentfulDeliveryAPI               0x000000010a144f0c -[UIImageView(CDAAsset) hideActivityIndicator] + 140
	9   ContentfulDeliveryAPI               0x000000010a1436ed __70-[UIImageView(CDAAsset) cda_fetchImageWithAsset:URL:placeholderImage:]_block_invoke + 349
	10  CFNetwork                           0x000000010eaf8ccc __75-[__NSURLSessionLocal taskForClass:request:uploadFile:bodyData:completion:]_block_invoke + 19
	11  CFNetwork                           0x000000010eaf8578 __49-[__NSCFLocalSessionTask _task_onqueue_didFinish]_block_invoke + 308
	12  Foundation                          0x000000010b3489ad __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 7
	13  Foundation                          0x000000010b34868f -[NSBlockOperation main] + 101
	14  Foundation                          0x000000010b346d8c -[__NSOperationInternal _start:] + 672
	15  Foundation                          0x000000010b342ccf __NSOQSchedule_f + 201
	16  libdispatch.dylib                   0x000000010e67a0cd _dispatch_client_callout + 8
	17  libdispatch.dylib                   0x000000010e657e17 _dispatch_queue_serial_drain + 236
	18  libdispatch.dylib                   0x000000010e658b4b _dispatch_queue_invoke + 1073
	19  libdispatch.dylib                   0x000000010e65b385 _dispatch_root_queue_drain + 720
	20  libdispatch.dylib                   0x000000010e65b059 _dispatch_worker_thread3 + 123
	21  libsystem_pthread.dylib             0x000000010ea22712 _pthread_wqthread + 1299
	22  libsystem_pthread.dylib             0x000000010ea221ed start_wqthread + 13
> )