### PR TITLE
Update Realm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache:
 - cocoapods
 matrix:
   include:
-    - osx_image: xcode8.2
+    - osx_image: xcode8.3
       env: 
-      - SDK=iphonesimulator10.2 OS_VERSION=10.2 DEVICE_NAME='iPad Pro (12.9 inch)'
+      - SDK=iphonesimulator10.3 OS_VERSION=10.3 DEVICE_NAME='iPhone 6s'
     - osx_image: xcode7.3
       env: 
       - SDK=iphonesimulator9.3 OS_VERSION=9.3 DEVICE_NAME='iPhone 5s'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - osx_image: xcode8.3
       env: 
       - SDK=iphonesimulator10.3 OS_VERSION=10.3 DEVICE_NAME='iPhone 6s'
-    - osx_image: xcode7.3
-      env: 
-      - SDK=iphonesimulator9.3 OS_VERSION=9.3 DEVICE_NAME='iPhone 5s'
+#    - osx_image: xcode7.3
+#      env: 
+#      - SDK=iphonesimulator9.3 OS_VERSION=9.3 DEVICE_NAME='iPhone 5s'
 before_install:
 - git config --file=.gitmodules submodule.Submodules/ContentfulPersistence.url https://github.com/contentful/contentful-persistence.objc.git
 - git submodule sync

--- a/Code/CDAPersistedAsset.h
+++ b/Code/CDAPersistedAsset.h
@@ -21,21 +21,21 @@
 @protocol CDAPersistedAsset <NSObject>
 
 /** The `sys.id` of the Asset. */
-@property (nonatomic) NSString* identifier;
+@property (nonatomic, nonnull) NSString* identifier;
 /** File type of the Asset. */
-@property (nonatomic) NSString* internetMediaType;
+@property (nonatomic, nullable) NSString* internetMediaType;
 /** URL for the underlying file represented by the Asset. */
-@property (nonatomic) NSString* url;
+@property (nonatomic, nullable) NSString* url;
 
 @optional
 
 /** The description of the Asset. */
-@property (nonatomic) NSString* assetDescription;
+@property (nonatomic, nullable) NSString* assetDescription;
 /** The title of the Asset. */
-@property (nonatomic) NSString* title;
+@property (nonatomic, nullable) NSString* title;
 /** The width of the Asset, if it is an image. */
-@property (nonatomic) NSNumber* width;
+@property (nonatomic, nullable) NSNumber* width;
 /** The height of the Asset, if it is an image. */
-@property (nonatomic) NSNumber* height;
+@property (nonatomic, nullable) NSNumber* height;
 
 @end

--- a/ContentfulDeliveryAPI.podspec
+++ b/ContentfulDeliveryAPI.podspec
@@ -2,7 +2,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = "ContentfulDeliveryAPI"
-  s.version          = "2.0.0"
+  s.version          = "2.0.1"
   s.summary          = "Objective-C SDK for Contentful's Content Delivery API."
   s.homepage         = "https://github.com/contentful/contentful.objc/"
   s.social_media_url = 'https://twitter.com/contentful'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 __SIM_ID=`xcrun simctl list|egrep -m 1 '$(SIM_NAME) \([^(]*\) \([^(]*\)$$'|sed -e 's/.* (\(.*\)) (.*)/\1/'`
-SIM_NAME=iPhone 5s
+SIM_NAME=iPhone 6s
 SIM_ID=$(shell echo $(__SIM_ID))
 
 ifeq ($(strip $(SIM_ID)),)
@@ -60,7 +60,7 @@ kill_simulator:
 test: clean_simulators really_clean
 	set -x -o pipefail && xcodebuild test -workspace $(WORKSPACE) \
 		-scheme 'ContentfulDeliveryAPI' -sdk iphonesimulator \
-		-destination 'platform=iOS Simulator,name=iPhone 5s,OS=10.2'| xcpretty -c 
+		-destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.3'| xcpretty -c 
 	kill_simulator	
 	bundle exec pod lib coverage
 

--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,7 @@ target "ContentfulDeliveryAPI" do
     pod 'CCLRequestReplay', :git => 'https://github.com/neonichu/CCLRequestReplay.git'
     pod 'OCMock'
     pod 'VCRURLConnection', :inhibit_warnings => true
-    pod 'Realm', '= 0.98.8' # Realm must be linked for the persistence layer and should match the same version in the submodule
+    pod 'Realm', '~> 2.5.0' # Realm must be linked for the persistence layer and should match the same version in the submodule
     pod 'FBSnapshotTestCase/Core'
   end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,9 +29,9 @@ PODS:
   - ISO8601 (0.6.0)
   - OCMock (3.4)
   - PDKTCollectionViewWaterfallLayout (0.1)
-  - Realm (0.98.8):
-    - Realm/Headers (= 0.98.8)
-  - Realm/Headers (0.98.8)
+  - Realm (2.5.0):
+    - Realm/Headers (= 2.5.0)
+  - Realm/Headers (2.5.0)
   - VCRURLConnection (0.2.2)
 
 DEPENDENCIES:
@@ -41,7 +41,7 @@ DEPENDENCIES:
   - ISO8601 (~> 0.6.0)
   - OCMock
   - PDKTCollectionViewWaterfallLayout
-  - Realm (= 0.98.8)
+  - Realm (~> 2.5.0)
   - VCRURLConnection
 
 EXTERNAL SOURCES:
@@ -60,9 +60,9 @@ SPEC CHECKSUMS:
   ISO8601: d3ea3ba9b752820cf92c6b47a9ee327e9f0e13fc
   OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   PDKTCollectionViewWaterfallLayout: a246de22e843bdb2677ab2fe5d6c1fb0a623f93e
-  Realm: 0e293bb62999730599efc3048896bbd4f2e43bcd
+  Realm: 62abce501668580092d2be9b6ba7324a3d5f906a
   VCRURLConnection: 1b14489604ca90b7b144b50dab6f9845d8931a45
 
-PODFILE CHECKSUM: 999b9c7192de00f92b1b1d7706de5e3f90907143
+PODFILE CHECKSUM: fe5feb1a2ede7855a7127f03c35fa1567e9f94d6
 
 COCOAPODS: 1.2.0

--- a/Tests/PersistenceBaseTest+QuerySync.m
+++ b/Tests/PersistenceBaseTest+QuerySync.m
@@ -7,6 +7,7 @@
 //
 
 #import "PersistenceBaseTest+QuerySync.h"
+#import "RealmAsset.h"
 
 @implementation PersistenceBaseTest (QuerySync)
 
@@ -133,6 +134,8 @@
 }
 
 -(void)querySync_updateAsset {
+
+
     [self querySync_stubInitialRequestWithJSONNamed:@"initial2" updateWithJSONNamed:@"update-asset"];
 
     [self addRecordingWithJSONNamed:@"update-asset-assets"
@@ -147,8 +150,10 @@
         [self assertNumberOfAssets:1 numberOfEntries:2];
 
         id<CDAPersistedAsset> asset = [[self.persistenceManager fetchAssetsFromDataStore] firstObject];
+
         XCTAssertEqualObjects(@"3f5a00acf72df93528b6bb7cd0a4fd0c.jpeg",
                               asset.url.lastPathComponent, @"");
+
         XCTAssertNil(asset.assetDescription);
         XCTAssertEqualObjects(@"3f5a00acf72df93528b6bb7cd0a4fd0c", asset.title);
 

--- a/Tests/RealmAdvancedTests.m
+++ b/Tests/RealmAdvancedTests.m
@@ -95,7 +95,7 @@ RLM_ARRAY_TYPE(RealmMember)
         XCTAssertEqual(4U, [self.persistenceManager fetchAssetsFromDataStore].count, @"");
         XCTAssertEqual(3U, [self.persistenceManager fetchEntriesFromDataStore].count, @"");
 
-        RealmClassHierarchy* nyancat = [self.persistenceManager fetchEntryWithIdentifier:@"nyancat"];
+        RealmClassHierarchy* nyancat = (RealmClassHierarchy*)[self.persistenceManager fetchEntryWithIdentifier:@"nyancat"];
         XCTAssertNotNil(nyancat);
         RealmClassHierarchy* friend = nyancat.bestFriend;
         XCTAssertNotNil(friend);

--- a/scripts/travis-build-test.sh
+++ b/scripts/travis-build-test.sh
@@ -4,9 +4,9 @@ set -x -o pipefail
 
 echo "Building"
 
-make clean_simulators
+#make clean_simulators
 
-rm -rf ${HOME}/Library/Developer/Xcode/DerivedData/*
+#rm -rf ${HOME}/Library/Developer/Xcode/DerivedData/*
 
 # -jobs -- specify the number of concurrent jobs
 # `sysctl -n hw.ncpu` -- fetch number of 'logical' cores in macOS machine


### PR DESCRIPTION
The reason for this update is that the persistence library is currently not publishable to the central Cocoapods specs repo as it is using a version of Realm that is _very_ old. Now, Realm only supports Xcode 8, and as a consequence, this PR drops support for Xcode 7.

See https://github.com/contentful/contentful.objc/pull/78